### PR TITLE
feat(ci): add vibe-coded badge action and README badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,3 +372,14 @@ jobs:
           else
             echo "All jobs passed successfully"
           fi
+
+  vibe-badge:
+    name: Generate Vibe Badge
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate Vibe Badge
+        uses: trieloff/vibe-coded-badge-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ScriptRAG: A Graph-Based Screenwriting Assistant
 
+![Vibe](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftrieloff%2Fscriptrag2%2Fmain%2Fvibe.json&query=%24.vibe&style=for-the-badge&logo=github&label=Vibe&color=ff69b4)
+
 ScriptRAG is a novel screenwriting tool that combines Fountain parsing, graph databases, and local LLMs
 to create an intelligent screenplay assistant using the GraphRAG (Graph + Retrieval-Augmented
 Generation) pattern.


### PR DESCRIPTION
## Summary
- Add GitHub workflow step to generate vibe badge using trieloff/vibe-coded-badge-action
- Add dynamic vibe badge to README.md that displays the project's current vibe

## Test plan
- [ ] Verify the workflow runs successfully on main branch
- [ ] Check that the badge displays correctly in README
- [ ] Confirm the badge updates when vibe.json is generated

🤖 Generated with [Claude Code](https://claude.ai/code)