### PR TITLE
Enhance knowledge graph builder with enrichment limits and prompt sanitization

### DIFF
--- a/src/scriptrag/parser/__init__.py
+++ b/src/scriptrag/parser/__init__.py
@@ -70,6 +70,7 @@ class FountainParser:
         """Initialize the fountain parser."""
         self.jouvence_parser = JouvenceParser()
         self._characters_cache: dict[str, Character] = {}
+        self._scenes_cache: list[Scene] = []
         self._scene_count = 0
 
     def parse_file(self, file_path: str | Path) -> Script:
@@ -128,6 +129,7 @@ class FountainParser:
         """Convert a Jouvence document to a ScriptRAG Script model."""
         # Reset parser state
         self._characters_cache.clear()
+        self._scenes_cache.clear()
         self._scene_count = 0
 
         # Extract title page metadata
@@ -159,6 +161,7 @@ class FountainParser:
         # Parse all scenes
         scenes = self._parse_scenes(document.scenes, script.id)
         script.scenes = [scene.id for scene in scenes]
+        self._scenes_cache = scenes  # Store scenes for retrieval
 
         # Extract all characters
         characters = list(self._characters_cache.values())
@@ -426,6 +429,22 @@ class FountainParser:
                     title_values[key.lower()] = value
 
         return title_values
+
+    def get_characters(self) -> list[Character]:
+        """Get all parsed characters.
+
+        Returns:
+            List of Character objects that have been parsed
+        """
+        return list(self._characters_cache.values())
+
+    def get_scenes(self) -> list[Scene]:
+        """Get all parsed scenes.
+
+        Returns:
+            List of Scene objects that have been parsed
+        """
+        return list(self._scenes_cache)
 
 
 # Export the main parser class


### PR DESCRIPTION
## Summary
- Adds options to limit the number of scenes and characters enriched in the knowledge graph builder
- Introduces prompt sanitization to prevent prompt injection attacks during LLM enrichment
- Updates example script to support keeping existing database and to pass parsed characters and scenes explicitly
- Improves character mention extraction with caching and whole-word matching
- Extends FountainParser to cache and expose parsed scenes and characters

## Changes

### Core Functionality
- **KnowledgeGraphBuilder**:
  - Added `max_scenes_to_enrich` and `max_characters_to_enrich` parameters to constructor
  - Updated `build_from_script` to accept explicit `characters` and `scenes` lists
  - Improved character mention extraction to use cached character names and whole-word matching
  - Added `_sanitize_for_prompt` method to clean text inputs before sending to LLM
  - Applied sanitization in scene and character enrichment prompts
- **FountainParser**:
  - Cache parsed scenes and expose via `get_scenes()` method
  - Expose parsed characters via `get_characters()` method

### Example Script (`examples/build_knowledge_graph.py`)
- Added CLI argument `--keep-existing` to optionally preserve existing database
- Pass parsed characters and scenes explicitly to `KnowledgeGraphBuilder.build_from_script`
- Set enrichment limits for demo purposes (10 scenes, 5 characters)

## Test plan
- [x] Run example script with and without `--keep-existing` flag
- [x] Verify knowledge graph builds correctly with limited enrichment
- [x] Confirm prompt sanitization prevents injection patterns
- [x] Validate character mention extraction accuracy
- [x] Ensure parsed scenes and characters are correctly retrieved from parser

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7499cc77-e74b-4260-9f31-d5b7a2bf9739