### PR TITLE
Disable markdown line length limit in markdownlint config

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -38,14 +38,7 @@ MD012:
   maximum: 2
 
 # MD013/line-length - Line length
-MD013:
-  line_length: 300
-  heading_line_length: 300
-  code_blocks: false
-  tables: false
-  headings: true
-  strict: false
-  stern: false
+MD013: false  # Disabled - no line length limit for markdown files
 
 # MD014/commands-show-output - Dollar signs used before commands without showing output
 MD014: true


### PR DESCRIPTION
## Summary
- Removes the line length limit enforcement for markdown files in the markdownlint configuration
- Disables the MD013 rule entirely to allow unlimited line length

## Changes

### Configuration Update
- Modified `.markdownlint.yaml` to disable the MD013 rule (line length limit) by setting it to `false`
- Removed previous settings that limited line length to 300 characters for headings and lines

## Test plan
- Verify markdownlint no longer reports line length warnings or errors for markdown files
- Confirm that markdown files with long lines pass linting without issues

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/21acb92e-2be8-4d29-b5a2-923639818a21