### PR TITLE
Fix safety command output redirection in Makefile security target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ type-check: ## Run type checking with mypy
 .PHONY: security
 security: ## Run security checks (bandit, safety, pip-audit)
 	@bash -c 'source .venv/bin/activate && bandit -r src/ -c pyproject.toml -f json -o .bandit-report.json'
-	@bash -c 'source .venv/bin/activate && safety check --json --output .safety-report.json || true'
+	@bash -c 'source .venv/bin/activate && safety check --json > .safety-report.json || true'
 	@bash -c 'source .venv/bin/activate && pip-audit || true'
 	@echo "✅ Security scan complete (see .bandit-report.json and .safety-report.json)"
 


### PR DESCRIPTION
## Summary
- Corrects the output redirection for the `safety check` command in the Makefile's `security` target
- Changes from using `--output` option to shell redirection `>` to properly save JSON report

## Changes

### Makefile
- Updated the `security` target:
  - Replaced `safety check --json --output .safety-report.json` with `safety check --json > .safety-report.json` to fix output file generation

## Test plan
- Run `make security` and verify that `.safety-report.json` is correctly created with JSON output
- Confirm that other security tools (`bandit`, `pip-audit`) run without issues
- Check that the success message is printed after the scan completes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/655e99db-e748-4356-adb0-5ac93b0b6a0b