### PR TITLE
Replace interrogate with docstr-coverage for docstring checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,18 +74,20 @@ repos:
         additional_dependencies: ['bandit[toml]']
         exclude: '^tests/'
 
-  # Docstring coverage - temporarily disabled due to pkg_resources issue in newer Python versions
-  # - repo: https://github.com/econchick/interrogate
-  #   rev: 1.7.0
-  #   hooks:
-  #     - id: interrogate
-  #       args: [
-  #         --quiet, --fail-under=60, --ignore-init-method, --ignore-init-module,
-  #         --ignore-magic, --ignore-semiprivate, --ignore-private,
-  #         --ignore-property-decorators, --ignore-module, --ignore-nested-functions,
-  #         --ignore-nested-classes, --exclude, 'tests', --exclude, 'docs',
-  #         --exclude, 'scripts', --verbose
-  #       ]
+  # Docstring coverage - using docstr-coverage (Python 3.12+ compatible)
+  - repo: https://github.com/HunterMcGushion/docstr_coverage
+    rev: v2.3.2
+    hooks:
+      - id: docstr-coverage
+        args: [
+          'src/',
+          '--fail-under', '60',
+          '--skip-magic', '--skip-init', '--skip-class-def',
+          '--skip-private', '--skip-property',
+          '--exclude', 'tests/*', '--exclude', 'docs/*',
+          '--exclude', 'scripts/*', '--exclude', '.venv/*',
+          '--verbose', '2'
+        ]
 
   # Check for common security issues - now enabled
   - repo: https://github.com/Yelp/detect-secrets


### PR DESCRIPTION
## Summary
- Replaced the disabled `interrogate` hook with `docstr-coverage` in the pre-commit configuration
- Ensures docstring coverage checks are compatible with Python 3.12+
- Maintains a minimum docstring coverage threshold of 60%

## Changes

### Pre-commit Configuration
- Removed the commented-out `interrogate` hook due to compatibility issues with newer Python versions
- Added `docstr-coverage` hook from https://github.com/HunterMcGushion/docstr_coverage at version v2.3.2
- Configured `docstr-coverage` to check the `src/` directory with exclusions for `tests/`, `docs/`, `scripts/`, and `.venv/`
- Set arguments to skip magic methods, init methods, class definitions, private methods, and properties
- Enabled verbose output level 2 for detailed reporting

## Test plan
- Verified that the new pre-commit hook runs without errors on Python 3.12 environment
- Confirmed that docstring coverage enforcement triggers if coverage falls below 60%
- Ensured excluded directories and files are not checked by the hook

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/2b53900b-1aad-4be2-b365-a347d0817089