### PR TITLE
Update pre-commit hooks configuration and switch to pip-audit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-  python: python3.12
+  python: python3
 
 repos:
   # General file checks
@@ -39,7 +39,6 @@ repos:
     rev: 25.1.0
     hooks:
       - id: black
-        language_version: python3.12
         args: ['--line-length=88']
 
   # Python linting and import sorting with Ruff
@@ -112,12 +111,12 @@ repos:
       - id: yamllint
         args: ['-c', '.yamllint.yaml']
 
-  # Python dependency safety check - disabled as it only supports Poetry projects
-  # - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-  #   rev: v1.4.2
-  #   hooks:
-  #     - id: python-safety-dependencies-check
-  #       args: ['--disable-optional-telemetry']
+  # Python dependency safety check using pip-audit instead of safety
+  - repo: https://github.com/pypa/pip-audit
+    rev: v2.9.0
+    hooks:
+      - id: pip-audit
+        args: ['--desc', 'on', '--fix']
 
   # Check for print statements
   - repo: https://github.com/pre-commit/pygrep-hooks


### PR DESCRIPTION
## Summary
- Updated Python version in pre-commit configuration from 3.12 to 3
- Removed explicit language version for Black hook to use default
- Replaced deprecated Python safety check with pip-audit for dependency auditing

## Changes

### Pre-commit Configuration
- Changed `default_language_version` for Python from `python3.12` to `python3` for broader compatibility
- Removed `language_version: python3.12` from Black hook to rely on default interpreter
- Disabled the old `python-safety-dependencies-check` hook which only supports Poetry projects
- Added `pip-audit` hook (version 2.9.0) with arguments to enable descriptions and automatic fixes

## Test plan
- [x] Verified pre-commit hooks run successfully with updated Python version
- [x] Confirmed Black formatting works without explicit language version
- [x] Tested pip-audit hook detects and fixes vulnerable dependencies
- [x] Ensured no errors occur during pre-commit checks after changes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d4207b76-66ab-49f2-a31e-0d8da0470896