### PR TITLE
Fix CI: Only notify Terragon Labs about failures they can control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,6 +415,12 @@ jobs:
               .filter(([_, status]) => status === 'failure')
               .map(([job, _]) => job);
 
+            // Only notify if there are actual CI failures (not external job failures)
+            if (failedJobs.length === 0) {
+              console.log('No CI jobs failed that are under Terragon Labs control');
+              return;
+            }
+
             const runUrl = `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
 
             const comment = [
@@ -426,7 +432,9 @@ jobs:
               `- [View full CI run](${runUrl})`,
               `- [Terry Task](${taskUrl})`,
               '',
-              `You can use \`terry pull ${{ steps.extract-task.outputs.task_id }}\` to continue working on this task.`
+              `You can use \`terry pull ${{ steps.extract-task.outputs.task_id }}\` to continue working on this task.`,
+              '',
+              '_Note: This notification only includes CI checks that are part of the core build process. External checks like Claude Code Review are excluded._'
             ].join('\n');
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
## Summary
- Modified the CI workflow to exclude external job failures (like Claude Code Review) from Terragon Labs notifications
- Added a check to only post comments when there are actual CI job failures
- Added a clarifying note in the notification

## Problem
Terragon Labs was being tagged when the Claude Code Review job failed, even though this is outside their control and not something they can fix.

## Solution
The `notify-terry` job now:
- Only monitors core CI jobs (lint, type-check, security, test, docs, build, pre-commit)
- Skips notification if no core jobs failed
- Includes a note explaining that external checks are excluded

This ensures Terragon Labs is only notified about failures they can actually address.

## Test plan
- [x] Updated CI workflow with conditional check
- [x] Added clarifying note to the notification message
- [ ] CI will test this change on this PR

🤖 Generated with [Claude Code](https://claude.ai/code)