### PR TITLE
fix(ci): update dependabot configuration to use uv package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "uv" # Python dependency management with uv
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary
- Fixed invalid dependabot.yml configuration that had an empty package-ecosystem value
- Updated to use `uv` as the package ecosystem for Python dependency management

## Test plan
- [x] Dependabot configuration now validates successfully
- [x] Package ecosystem correctly set to `uv` for Python projects using uv

🤖 Generated with [Claude Code](https://claude.ai/code)