### PR TITLE
Remove Black formatter in favor of Ruff-only formatting

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -17,7 +17,7 @@ The hooks are configured in `.claude/config.json` and trigger after:
 
 Comprehensive auto-formatting script that handles:
 
-- **Python files**: Black formatting + Ruff linting/formatting
+- **Python files**: Ruff linting/formatting
 - **Markdown files**: markdownlint auto-fix
 - **JSON files**: Python JSON.tool formatting
 - **YAML files**: yamllint validation
@@ -27,15 +27,14 @@ Comprehensive auto-formatting script that handles:
 
 Lightweight Python-only formatting script that:
 
-- Runs Black formatter on Python files
-- Applies Ruff formatting and auto-fixes
+- Applies Ruff formatting and auto-fixes on Python files
 - Faster execution for Python-only changes
 
 ## How It Works
 
 1. **File Detection**: Scripts detect modified files from git status
 2. **Virtual Environment**: Automatically activates `.venv` if available
-3. **Tool Selection**: Uses project's existing tools (Black, Ruff, etc.)
+3. **Tool Selection**: Uses project's existing tools (Ruff, markdownlint, etc.)
 4. **Safe Execution**: Continues on errors, provides helpful feedback
 5. **Git Integration**: Can optionally re-stage formatted files
 
@@ -43,7 +42,6 @@ Lightweight Python-only formatting script that:
 
 The hooks expect these tools to be available (installed via `make setup-dev`):
 
-- `black` - Python code formatter
 - `ruff` - Python linter and formatter
 - `markdownlint` - Markdown linter (optional)
 - `yamllint` - YAML linter (optional)
@@ -133,4 +131,4 @@ These hooks complement the existing pre-commit hooks in `.pre-commit-config.yaml
 - **Claude hooks**: Run automatically during development
 - **Pre-commit hooks**: Run before commits for validation
 
-Both use the same tools (Black, Ruff, etc.) to ensure consistency.
+Both use the same tools (Ruff, markdownlint, etc.) to ensure consistency.

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -17,7 +17,7 @@ The hooks are configured in `.claude/config.json` and trigger after:
 
 Comprehensive auto-formatting script that handles:
 
-- **Python files**: Ruff linting/formatting
+- **Python files**: Ruff linting and formatting (replaces Black)
 - **Markdown files**: markdownlint auto-fix
 - **JSON files**: Python JSON.tool formatting
 - **YAML files**: yamllint validation

--- a/.claude/hooks/auto-format.sh
+++ b/.claude/hooks/auto-format.sh
@@ -59,12 +59,6 @@ if [ -n "$PYTHON_FILES" ]; then
     done
 
     if [ -n "$EXISTING_PYTHON_FILES" ]; then
-        # Run Black formatter
-        if command -v black >/dev/null 2>&1; then
-            echo "  Running Black..."
-            black $EXISTING_PYTHON_FILES || echo "  ⚠️  Black formatting failed"
-        fi
-
         # Run Ruff formatter and fixer
         if command -v ruff >/dev/null 2>&1; then
             echo "  Running Ruff..."

--- a/.claude/hooks/format-python.sh
+++ b/.claude/hooks/format-python.sh
@@ -29,11 +29,6 @@ fi
 if [[ "$TARGET_FILE" =~ \.py$ ]]; then
     echo "🐍 Formatting Python file: $TARGET_FILE"
 
-    # Run Black formatter
-    if command -v black >/dev/null 2>&1; then
-        black "$TARGET_FILE" 2>/dev/null || true
-    fi
-
     # Run Ruff formatter and fixer
     if command -v ruff >/dev/null 2>&1; then
         ruff format "$TARGET_FILE" 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,11 +77,6 @@ jobs:
           source .venv/bin/activate
           ruff format --check src tests
 
-      - name: Run Black formatter
-        run: |
-          source .venv/bin/activate
-          black --check src tests
-
       - name: Check docstring coverage
         run: |
           source .venv/bin/activate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,13 +34,6 @@ repos:
       - id: check-builtin-literals
       - id: check-docstring-first
 
-  # Python code formatting with Black
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-      - id: black
-        args: ['--line-length=88']
-
   # Python linting and import sorting with Ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ This project includes Claude Code hooks that automatically format code when
 files are modified. The hooks are configured in `.claude/config.json` and run
 after Write/Edit/MultiEdit operations:
 
-- **Python files**: Automatically formatted with Black and Ruff
+- **Python files**: Automatically formatted with Ruff
 - **Markdown files**: Fixed with markdownlint
 - **JSON/YAML files**: Formatted and validated
 - **All files**: Trailing whitespace removed, proper line endings ensured
@@ -94,7 +94,7 @@ after Write/Edit/MultiEdit operations:
 
 ### **Python Code Style (Immediate Rules)**
 
-- **Line Length**: 88 characters (Black standard)
+- **Line Length**: 88 characters (Ruff standard)
 - **Quotes**: Double quotes for strings (`"hello"` not `'hello'`)
 - **Indentation**: 4 spaces, no tabs
 - **Line Endings**: LF only (Unix style)
@@ -197,7 +197,7 @@ make setup-dev          # Complete dev environment setup
 make update             # Update all dependencies
 
 # Code quality (run before commits)
-make format             # Format code with black/ruff
+make format             # Format code with ruff
 make lint              # Run all linters
 make type-check        # Type checking with mypy
 make check             # Run all quality checks

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,7 @@ update: ## Update all dependencies to latest versions
 
 # Code quality
 .PHONY: format
-format: ## Format code with black and ruff
-	@bash -c 'source .venv/bin/activate && black src/ tests/'
+format: ## Format code with ruff
 	@bash -c 'source .venv/bin/activate && ruff check --fix src/ tests/'
 	@bash -c 'source .venv/bin/activate && ruff format src/ tests/'
 	@echo "✅ Code formatted"
@@ -227,7 +226,7 @@ check: lint type-check security test ## Run all quality checks
 check-fast: ## Run fast quality checks (no tests)
 	@bash -c 'source .venv/bin/activate && ruff check src/ tests/'
 	@bash -c 'source .venv/bin/activate && mypy src/ --no-error-summary'
-	@bash -c 'source .venv/bin/activate && black --check src/ tests/'
+	@bash -c 'source .venv/bin/activate && ruff format --check src/ tests/'
 
 .PHONY: pre-commit
 pre-commit: ## Run pre-commit on all files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ dev = [
 
     # Code quality
     "ruff>=0.1.0",
-    "black>=23.12.0",
     "isort>=5.13.0",
     "mypy>=1.8.0",
     "types-PyYAML>=6.0.0",
@@ -249,7 +248,7 @@ reportGeneralTypeIssues = false
 stubPath = "./typings"
 
 [tool.isort]
-profile = "black"
+profile = "ruff"
 multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0
@@ -311,11 +310,9 @@ commands = pytest {posargs}
 [testenv:lint]
 deps =
     ruff
-    black
     interrogate
 commands =
     ruff check src tests
-    black --check src tests
     interrogate -c pyproject.toml
 
 [testenv:type]


### PR DESCRIPTION
## Summary
- Removed Black formatter from all project configuration and scripts
- Project now uses Ruff exclusively for Python formatting
- Eliminates formatting conflicts between Black and Ruff

## Changes
- **Dependencies**: Removed `black>=23.12.0` from `pyproject.toml`
- **Pre-commit**: Removed Black hook from `.pre-commit-config.yaml`
- **CI/CD**: Removed Black formatter step from GitHub Actions workflow
- **Makefile**: Updated format and check-fast targets to use Ruff only
- **Documentation**: Updated references in CLAUDE.md and hook documentation
- **Shell scripts**: Removed Black commands from auto-format hooks

## Test plan
- [ ] Verify CI passes with Ruff-only formatting
- [ ] Test local development workflow with `make format`
- [ ] Confirm pre-commit hooks work without Black
- [ ] Check that auto-format hooks function correctly

## Rationale
Having two Python formatters (Black and Ruff) can lead to conflicts and inconsistent formatting. Since Ruff provides both linting and formatting capabilities, standardizing on Ruff simplifies the toolchain and eliminates potential conflicts.

🤖 Generated with [Claude Code](https://claude.ai/code)