### PR TITLE
Fix uv command not found by creating symlink in PATH

### DIFF
--- a/terragon-setup.sh
+++ b/terragon-setup.sh
@@ -234,8 +234,19 @@ if ! command -v uv &> /dev/null; then
     if ! command -v uv &> /dev/null; then
         log_info "uv not found in PATH after installation, checking explicit location..."
         if [ -x "$HOME/.local/bin/uv" ]; then
-            log_info "Found uv at $HOME/.local/bin/uv, using explicit path"
-            UV_CMD="$HOME/.local/bin/uv"
+            log_info "Found uv at $HOME/.local/bin/uv"
+            # Create symlink to make uv available system-wide
+            log_info "Creating symlink to make uv available in PATH..."
+            sudo ln -sf "$HOME/.local/bin/uv" /usr/local/bin/uv || {
+                log_warning "Failed to create symlink, using explicit path"
+                UV_CMD="$HOME/.local/bin/uv"
+            }
+            # Check if symlink worked
+            if command -v uv &> /dev/null; then
+                log_success "uv is now available in PATH"
+            else
+                UV_CMD="$HOME/.local/bin/uv"
+            fi
         else
             log_error "Cannot find uv executable after installation"
             exit 1


### PR DESCRIPTION
## Summary
- Fixes issue where `uv` command is not found in PATH after installation
- Adds logic to create a symlink from `$HOME/.local/bin/uv` to `/usr/local/bin/uv` to make `uv` available system-wide
- Falls back to using explicit path if symlink creation fails

## Changes

### terragon-setup.sh
- After installing `uv`, checks if `uv` is available in PATH
- If not found, checks for executable at `$HOME/.local/bin/uv`
- Creates a symlink at `/usr/local/bin/uv` pointing to `$HOME/.local/bin/uv` using `sudo ln -sf`
- Logs success or warning messages based on symlink creation outcome
- Uses explicit path if symlink creation or command detection fails

## Test plan
- Run the setup script on a system without `uv` in PATH
- Verify that `uv` is installed and symlinked correctly
- Confirm that `uv` command is available globally after setup
- Test fallback to explicit path if symlink creation is not permitted or fails

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/707cadfe-4c9d-49f4-9e98-0edc881eeaf3