### PR TITLE
Migrate to Pydantic v2 Serializers in Mentor and Model Classes

### DIFF
--- a/src/scriptrag/mentors/base.py
+++ b/src/scriptrag/mentors/base.py
@@ -12,7 +12,7 @@ from enum import Enum
 from typing import Any
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 
 class MentorType(str, Enum):
@@ -77,12 +77,17 @@ class MentorAnalysis(BaseModel):
         default_factory=dict, description="Additional mentor-specific data"
     )
 
-    model_config = ConfigDict(
-        json_encoders={
-            UUID: str,
-            datetime: lambda v: v.isoformat(),
-        }
-    )
+    model_config = ConfigDict()
+
+    @field_serializer("id")
+    def serialize_uuid(self, value: UUID) -> str:
+        """Serialize UUID to string."""
+        return str(value)
+
+    @field_serializer("scene_id", "character_id", "element_id")
+    def serialize_optional_uuid(self, value: UUID | None) -> str | None:
+        """Serialize optional UUID to string."""
+        return str(value) if value else None
 
 
 class MentorResult(BaseModel):
@@ -115,12 +120,17 @@ class MentorResult(BaseModel):
         default_factory=dict, description="Configuration used for analysis"
     )
 
-    model_config = ConfigDict(
-        json_encoders={
-            UUID: str,
-            datetime: lambda v: v.isoformat(),
-        }
-    )
+    model_config = ConfigDict()
+
+    @field_serializer("id", "script_id")
+    def serialize_uuid(self, value: UUID) -> str:
+        """Serialize UUID to string."""
+        return str(value)
+
+    @field_serializer("analysis_date")
+    def serialize_datetime(self, value: datetime) -> str:
+        """Serialize datetime to ISO format."""
+        return value.isoformat()
 
     @property
     def error_count(self) -> int:

--- a/src/scriptrag/models/__init__.py
+++ b/src/scriptrag/models/__init__.py
@@ -10,7 +10,7 @@ from enum import Enum
 from typing import Any, Literal
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 
 
 class ElementType(str, Enum):
@@ -54,12 +54,17 @@ class BaseEntity(BaseModel):
     updated_at: datetime = Field(default_factory=datetime.utcnow)
     metadata: dict[str, Any] = Field(default_factory=dict)
 
-    model_config = ConfigDict(
-        json_encoders={
-            UUID: str,
-            datetime: lambda v: v.isoformat(),
-        }
-    )
+    model_config = ConfigDict()
+
+    @field_serializer("id")
+    def serialize_uuid(self, value: UUID) -> str:
+        """Serialize UUID to string."""
+        return str(value)
+
+    @field_serializer("created_at", "updated_at")
+    def serialize_datetime(self, value: datetime) -> str:
+        """Serialize datetime to ISO format."""
+        return value.isoformat()
 
 
 class Location(BaseModel):


### PR DESCRIPTION
## Summary
- Migrates serialization logic in `MentorAnalysis`, `MentorResult`, and `BaseEntity` models to use Pydantic v2 `field_serializer` decorators
- Removes legacy `json_encoders` from `ConfigDict` and replaces with explicit field serializers for UUID and datetime fields

## Changes

### Mentor Models
- Added `field_serializer` methods in `MentorAnalysis` to serialize `id`, `scene_id`, `character_id`, and `element_id` UUID fields
- Added `field_serializer` methods in `MentorResult` to serialize `id`, `script_id` UUID fields and `analysis_date` datetime field
- Removed old `json_encoders` config from both classes

### BaseEntity Model
- Added `field_serializer` methods to serialize `id` UUID and `created_at`, `updated_at` datetime fields
- Removed old `json_encoders` config

### Imports
- Updated imports to include `field_serializer` from Pydantic

## Test plan
- Verify that UUID fields are serialized as strings in JSON output
- Verify that datetime fields are serialized in ISO 8601 format
- Run existing unit tests to ensure no regressions in model serialization behavior

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6acdeab3-46d7-41cf-9555-e74b5ca365ec