### PR TITLE
Fix: Add verbose debugging for Windows CI test hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,35 @@ jobs:
         run: uv sync --extra test
         shell: bash
 
-      - name: Run tests with pytest
+      - name: Windows Debug Info
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Write-Host "=== Windows Debug Information ==="
+          Write-Host "Temp directory: $env:TEMP"
+          Write-Host "Number of CPUs: $env:NUMBER_OF_PROCESSORS"
+          Write-Host "Available memory:"
+          Get-CimInstance Win32_OperatingSystem | Select-Object TotalVisibleMemorySize, FreePhysicalMemory
+          Write-Host "Python location:"
+          Get-Command python
+          Write-Host "UV location:"
+          Get-Command uv
+          Write-Host "Current directory contents:"
+          Get-ChildItem -Force
+          Write-Host "================================="
+
+      - name: Run tests with pytest (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          echo "Starting pytest at $(date)"
+          echo "Python version: $(python --version)"
+          echo "OS: ${{ matrix.os }}"
+          echo "Runner: ${{ runner.os }}"
+          uv run pytest tests -n auto --dist loadscope -vv --tb=short --durations=20 --log-cli-level=DEBUG --cov=scriptrag --cov-report=xml --junit-xml=junit.xml
+          echo "Finished pytest at $(date)"
+
+      - name: Run tests with pytest (Linux/macOS)
+        if: runner.os != 'Windows'
         run: uv run pytest tests -n auto --dist loadscope -q --no-header --tb=short --cov=scriptrag --cov-report=xml --junit-xml=junit.xml
 
       - name: Upload test results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,8 @@ addopts = [
     "--strict-markers",
     "--cov=scriptrag",
     "--cov-report=xml",  # Only XML for codecov.io
+    "--timeout=300",  # 5 minute timeout per test
+    "--timeout-method=thread",  # Use thread method for Windows compatibility
 ]
 testpaths = ["tests"]
 pythonpath = ["src"]
@@ -148,6 +150,10 @@ markers = [
     "integration: marks tests as integration tests",
     "unit: marks tests as unit tests",
 ]
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)8s] %(name)s: %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 
 [tool.coverage.run]
 source = ["scriptrag"]


### PR DESCRIPTION
## Summary
- Add comprehensive logging to diagnose slow Windows CI tests
- Enable verbose output only for Windows to maintain CI speed on other platforms
- Add system diagnostics and test timeouts to identify bottlenecks

## Changes
- **Windows-specific verbose logging**: Added `-vv`, `--durations=20`, and `--log-cli-level=DEBUG` only for Windows test runs
- **System diagnostics**: Added Windows debug info showing memory, CPU, and environment details
- **Test timeouts**: Added 5-minute timeout per test to catch hanging tests
- **Preserved performance**: Linux/macOS tests remain in quiet mode for faster CI

## Test plan
- [ ] CI runs successfully on all platforms
- [ ] Windows tests show verbose output with timing information
- [ ] Linux/macOS tests run in quiet mode as before
- [ ] Any hanging tests are identified by the timeout mechanism

🤖 Generated with [Claude Code](https://claude.ai/code)