### PR TITLE
fix(ci): Add coverage combination step for parallel test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,12 +213,17 @@ jobs:
           echo "Python version: $(python --version)"
           echo "OS: ${{ matrix.os }}"
           echo "Runner: ${{ runner.os }}"
-          uv run pytest tests -n auto --dist loadscope -vv --tb=short --durations=20 --log-cli-level=DEBUG --cov=scriptrag --cov-report=xml --junit-xml=junit.xml
+          uv run pytest tests -n auto --dist loadscope -vv --tb=short --durations=20 --log-cli-level=DEBUG --cov=scriptrag --cov-report= --junit-xml=junit.xml
           echo "Finished pytest at $(date)"
 
       - name: Run tests with pytest (Linux/macOS)
         if: runner.os != 'Windows'
-        run: uv run pytest tests -n auto --dist loadscope -q --no-header --tb=short --cov=scriptrag --cov-report=xml --junit-xml=junit.xml
+        run: uv run pytest tests -n auto --dist loadscope -q --no-header --tb=short --cov=scriptrag --cov-report= --junit-xml=junit.xml
+
+      - name: Combine coverage data
+        run: |
+          uv run coverage combine
+          uv run coverage xml
 
       - name: Upload test results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Fixed CI coverage reporting to properly combine data from parallel test workers
- Resolves ~1.6% coverage discrepancy between local (70.35%) and CI (68.75%) reports

## Problem
The recent parallel test coverage configuration (PR #98) added the necessary settings but CI workflow wasn't combining coverage data from multiple pytest-xdist workers before generating the XML report for Codecov.

## Solution
Updated the CI workflow to:
1. Run tests with coverage collection but no report generation (`--cov-report=`)
2. Add explicit `coverage combine` step to merge data from all parallel workers
3. Generate XML report after combination for accurate coverage reporting

## Test Plan
- [x] Verified coverage combination works locally with parallel tests
- [ ] CI will validate the fix when this PR runs
- [ ] Coverage percentage should increase closer to local measurements

🤖 Generated with [Claude Code](https://claude.ai/code)