### PR TITLE
fix(commands): correct gh pr status usage in ci-cycle command

### DIFF
--- a/.claude/commands/ci-cycle.md
+++ b/.claude/commands/ci-cycle.md
@@ -30,14 +30,18 @@ echo ""
 
 # Check if we're in a PR
 echo "🔍 Checking PR status..."
-gh pr status --json currentBranch,title,number,url,isDraft,state || echo "No PR found for current branch"
-
-# If PR exists, get detailed info
-PR_NUMBER=$(gh pr status --json currentBranch,number --jq '.currentBranch.number // empty' 2>/dev/null || echo "")
+PR_INFO=$(gh pr list --head "$BRANCH" --json number,title,state,url --limit 1)
+if [ -n "$PR_INFO" ] && [ "$PR_INFO" != "[]" ]; then
+    echo "$PR_INFO" | jq -r '.[0] | "PR #\(.number): \(.title)\nState: \(.state)\nURL: \(.url)"'
+    PR_NUMBER=$(echo "$PR_INFO" | jq -r '.[0].number // empty')
+else
+    echo "No PR found for current branch"
+    PR_NUMBER=""
+fi
 if [ -n "$PR_NUMBER" ]; then
     echo ""
     echo "📋 PR #$PR_NUMBER details:"
-    gh pr view "$PR_NUMBER" --json title,state,mergeable,checks --jq '. | "Title: \(.title)\nState: \(.state)\nMergeable: \(.mergeable)\nChecks: \(.checks | length) total"'
+    gh pr view "$PR_NUMBER" --json title,state,mergeable,statusCheckRollup --jq '. | "Title: \(.title)\nState: \(.state)\nMergeable: \(.mergeable)\nChecks: \(.statusCheckRollup | length) total"'
 
     echo ""
     echo "🔍 PR checks status:"


### PR DESCRIPTION
## Summary
- Fixed invalid JSON field usage in the ci-cycle command
- Command was failing with "Unknown JSON field: currentBranch" error

## Changes
- Replaced `gh pr status --json currentBranch` with `gh pr list --head` to find PRs
- Changed 'checks' field to 'statusCheckRollup' in `gh pr view` command
- Removed references to non-existent 'currentBranch' field

## Test plan
- [x] Command now correctly identifies PRs for the current branch
- [ ] CI passes
- [ ] ci-cycle command works end-to-end

This is a clean PR with only the ci-cycle.md fix, no unrelated changes.

🤖 Generated with [Claude Code](https://claude.ai/code)