### PR TITLE
ci: optimize workflow with fail-fast strategy for Windows tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           name: safety-report
           path: .safety-report.json
 
-  test:
+  test-unix:
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: changes
@@ -137,12 +137,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.12", "3.13"]
         exclude:
           # Reduce matrix for faster CI
-          - os: windows-latest
-            python-version: "3.13"
           - os: macos-latest
             python-version: "3.13"
 
@@ -174,35 +172,7 @@ jobs:
         run: make install
         shell: bash
 
-      - name: Windows Debug Info
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          Write-Host "=== Windows Debug Information ==="
-          Write-Host "Temp directory: $env:TEMP"
-          Write-Host "Number of CPUs: $env:NUMBER_OF_PROCESSORS"
-          Write-Host "Available memory:"
-          Get-CimInstance Win32_OperatingSystem | Select-Object TotalVisibleMemorySize, FreePhysicalMemory
-          Write-Host "Python location:"
-          Get-Command python
-          Write-Host "UV location:"
-          Get-Command uv
-          Write-Host "Current directory contents:"
-          Get-ChildItem -Force
-          Write-Host "================================="
-
-      - name: Run tests with pytest (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          echo "Starting pytest at $(date)"
-          echo "Python version: $(python --version)"
-          echo "OS: ${{ matrix.os }}"
-          echo "Runner: ${{ runner.os }}"
-          make test
-          echo "Finished pytest at $(date)"
-
-      - name: Run tests with pytest (Linux/macOS)
-        if: runner.os != 'Windows'
+      - name: Run tests with pytest
         run: make test
 
       - name: Upload test results
@@ -221,6 +191,76 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  test-windows:
+    name: Test Python ${{ matrix.python-version }} on Windows
+    runs-on: windows-latest
+    needs: [changes, test-unix]
+    if: needs.changes.outputs.python == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: uv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('**/uv.lock', '**/pyproject.toml') }}
+          restore-keys: |
+            uv-${{ runner.os }}-py${{ matrix.python-version }}-
+
+      - name: Install dependencies
+        run: make install
+        shell: bash
+
+      - name: Windows Debug Info
+        shell: pwsh
+        run: |
+          Write-Host "=== Windows Debug Information ==="
+          Write-Host "Temp directory: $env:TEMP"
+          Write-Host "Number of CPUs: $env:NUMBER_OF_PROCESSORS"
+          Write-Host "Available memory:"
+          Get-CimInstance Win32_OperatingSystem | Select-Object TotalVisibleMemorySize, FreePhysicalMemory
+          Write-Host "Python location:"
+          Get-Command python
+          Write-Host "UV location:"
+          Get-Command uv
+          Write-Host "Current directory contents:"
+          Get-ChildItem -Force
+          Write-Host "================================="
+
+      - name: Run tests with pytest
+        run: |
+          echo "Starting pytest at $(date)"
+          echo "Python version: $(python --version)"
+          echo "OS: windows-latest"
+          echo "Runner: ${{ runner.os }}"
+          make test
+          echo "Finished pytest at $(date)"
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-windows-latest-py${{ matrix.python-version }}
+          path: junit.xml
 
   docs:
     name: Build Documentation
@@ -308,7 +348,7 @@ jobs:
   integration:
     name: Integration Tests
     runs-on: ubuntu-latest
-    needs: [changes, lint, type-check, test]
+    needs: [changes, lint, type-check, test-unix]
     if: needs.changes.outputs.python == 'true'
 
     steps:
@@ -339,7 +379,7 @@ jobs:
   all-checks:
     name: All Checks Passed
     runs-on: ubuntu-latest
-    needs: [changes, lint, type-check, security, test, docs, build, pre-commit]
+    needs: [changes, lint, type-check, security, test-unix, test-windows, docs, build, pre-commit]
     if: always()
     steps:
       - name: Check if all jobs passed
@@ -361,7 +401,7 @@ jobs:
   notify-terry:
     name: Notify Terry on Failure
     runs-on: ubuntu-latest
-    needs: [changes, lint, type-check, security, test, docs, build, pre-commit]
+    needs: [changes, lint, type-check, security, test-unix, test-windows, docs, build, pre-commit]
     if: |
       always() &&
       github.event_name == 'pull_request' &&
@@ -398,7 +438,8 @@ jobs:
               lint: '${{ needs.lint.result }}',
               typeCheck: '${{ needs.type-check.result }}',
               security: '${{ needs.security.result }}',
-              test: '${{ needs.test.result }}',
+              testUnix: '${{ needs.test-unix.result }}',
+              testWindows: '${{ needs.test-windows.result }}',
               docs: '${{ needs.docs.result }}',
               build: '${{ needs.build.result }}',
               preCommit: '${{ needs.pre-commit.result }}'


### PR DESCRIPTION
## Summary

- Split test matrix into separate unix and windows jobs to prevent unnecessary Windows test runs when Linux/macOS tests fail
- Windows tests now depend on Unix tests completion, improving CI efficiency by avoiding slow Windows runners when there are known test failures
- Updated all job dependencies and references throughout the workflow

## Changes Made

- **Split test job**: Separated `test` into `test-unix` (Ubuntu + macOS) and `test-windows` 
- **Added dependency**: Windows tests now require Unix tests to pass first via `needs: [changes, test-unix]`
- **Updated references**: Modified `integration`, `all-checks`, and `notify-terry` jobs to reference both test jobs
- **Maintained coverage**: Same test scenarios, just better organized for efficiency

## Benefits

- **Faster feedback**: Windows tests won't start if Linux/macOS tests fail
- **Resource savings**: Avoids consuming GitHub Actions minutes on slow Windows runners when there are known failures
- **Better CI experience**: Developers get quicker failure notifications without waiting for all platforms

## Test Plan

- [x] Verify workflow syntax is valid (pre-commit hooks passed)
- [ ] Confirm Unix tests run first in CI
- [ ] Verify Windows tests are skipped when Unix tests fail
- [ ] Check that all existing functionality is preserved

🤖 Generated with [Claude Code](https://claude.ai/code)