### PR TITLE
Enhance script_info output with rich tables for node, edge, and time stats

### DIFF
--- a/src/scriptrag/cli.py
+++ b/src/scriptrag/cli.py
@@ -1139,15 +1139,29 @@ def script_info(
 
                     # Node types breakdown
                     if graph_stats["node_types"]:
-                        console.print("\n[bold]Node Types:[/bold]")
+                        console.print("\n[bold cyan]Node Types[/bold cyan]")
+                        node_types_table = RichTable(
+                            show_header=True, header_style="bold"
+                        )
+                        node_types_table.add_column("Type", style="dim")
+                        node_types_table.add_column("Count", justify="right")
+
                         for node_type, count in graph_stats["node_types"].items():
-                            console.print(f"  • {node_type}: {count:,}")
+                            node_types_table.add_row(node_type, f"{count:,}")
+                        console.print(node_types_table)
 
                     # Edge types breakdown
                     if graph_stats["edge_types"]:
-                        console.print("\n[bold]Edge Types:[/bold]")
+                        console.print("\n[bold cyan]Edge Types[/bold cyan]")
+                        edge_types_table = RichTable(
+                            show_header=True, header_style="bold"
+                        )
+                        edge_types_table.add_column("Type", style="dim")
+                        edge_types_table.add_column("Count", justify="right")
+
                         for edge_type, count in graph_stats["edge_types"].items():
-                            console.print(f"  • {edge_type}: {count:,}")
+                            edge_types_table.add_row(edge_type, f"{count:,}")
+                        console.print(edge_types_table)
 
                 # Embedding Statistics
                 embed_stats: dict[str, Any] = db_stats["embeddings"]
@@ -1217,8 +1231,13 @@ def script_info(
                 # Time of day distribution
                 if usage["common_times_of_day"]:
                     console.print("\n[bold cyan]Scene Times of Day[/bold cyan]")
+                    time_table = RichTable(show_header=True, header_style="bold")
+                    time_table.add_column("Time of Day", style="dim")
+                    time_table.add_column("Scenes", justify="right")
+
                     for time, count in list(usage["common_times_of_day"].items())[:5]:
-                        console.print(f"  • {time}: {count} scenes")
+                        time_table.add_row(time, str(count))
+                    console.print(time_table)
         else:
             console.print(
                 "[yellow]No database found. Use 'scriptrag script parse' "


### PR DESCRIPTION
## Summary
- Improves the visual presentation of script_info command output
- Replaces plain text lists with rich tables for node types, edge types, and scene times of day
- Adds color styling to section headers for better readability

## Changes

### CLI Output Enhancements
- Updated node types breakdown to use a RichTable with columns for type and count
- Updated edge types breakdown similarly with a RichTable
- Scene times of day statistics now displayed in a RichTable instead of plain text
- Section headers for node types, edge types, and scene times of day are now styled with bold cyan color for emphasis

## Test plan
- Run `scriptrag script info` on a database with node and edge types and verify tables render correctly
- Confirm counts are formatted with thousands separators
- Check that section headers appear in bold cyan color
- Validate that scene times of day table shows top 5 entries with correct counts

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/90919df8-adba-44fb-87ab-047003f69eb3