### PR TITLE
Fix LLMClient API key check for local endpoints

### DIFF
--- a/src/scriptrag/llm/client.py
+++ b/src/scriptrag/llm/client.py
@@ -50,8 +50,20 @@ class LLMClient:
 
         if not self.endpoint:
             raise LLMClientError("LLM endpoint not configured")
-        if not self.api_key:
+
+        # Check if endpoint is localhost/local URL
+        is_local = any(
+            self.endpoint.startswith(prefix)
+            for prefix in ["http://localhost", "http://127.0.0.1", "http://0.0.0.0"]
+        )
+
+        # Only require API key for non-local endpoints
+        if not is_local and not self.api_key:
             raise LLMClientError("LLM API key not configured")
+
+        # Use dummy key for local endpoints if none provided
+        if is_local and not self.api_key:
+            self.api_key = "dummy-key-for-local"  # pragma: allowlist secret
 
         # Extract base URL from endpoint (remove /chat/completions if present)
         base_url = self.endpoint.replace("/chat/completions", "").rstrip("/")


### PR DESCRIPTION
## Summary
- Adjust LLMClient to not require an API key for local endpoints (localhost, 127.0.0.1, 0.0.0.0)
- Use a dummy API key for local endpoints if none is provided
- Add tests to verify behavior for local and non-local endpoints

## Changes

### Core Functionality
- Modified `LLMClient` initialization to detect local endpoints and skip API key requirement
- Inject a dummy API key (`dummy-key-for-local`) for local endpoints when no key is set

### Tests
- Updated existing test to ensure missing API key raises error only for non-local endpoints
- Added new tests to verify client initialization succeeds without API key for various localhost URLs
- Confirmed dummy key usage and proper client setup for local endpoints

## Test plan
- [x] Run existing and new tests to verify API key enforcement logic
- [x] Confirm no errors raised for local endpoints without API key
- [x] Validate dummy key is used for local endpoint client initialization

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/50f21c24-0070-407f-a6fa-c07a3a8fd27e