### PR TITLE
Add ai-aligned-git installation step to terragon-setup.sh

### DIFF
--- a/terragon-setup.sh
+++ b/terragon-setup.sh
@@ -37,6 +37,7 @@ declare -A COMPLETED_STEPS=(
     ["python_check"]=0
     ["jq_install"]=0
     ["gh_workflow_peek"]=0
+    ["ai_aligned_git"]=0
     ["uv_install"]=0
     ["directories"]=0
     ["venv_create"]=0
@@ -53,6 +54,7 @@ declare -A STEP_DESCRIPTIONS=(
     ["python_check"]="Check Python version (3.11+)"
     ["jq_install"]="Install jq for git operations"
     ["gh_workflow_peek"]="Install gh-workflow-peek for CI analysis"
+    ["ai_aligned_git"]="Install ai-aligned-git for AI-safe git operations"
     ["uv_install"]="Install uv package manager"
     ["directories"]="Create required directories"
     ["venv_create"]="Create Python virtual environment"
@@ -83,7 +85,7 @@ show_remaining_steps() {
     log_info ""
     log_warning "⏳ Remaining steps to complete manually:"
     local has_remaining=0
-    for step in python_check jq_install gh_workflow_peek uv_install directories venv_create venv_activate pip_upgrade dependencies env_file pre_commit db_init; do
+    for step in python_check jq_install gh_workflow_peek ai_aligned_git uv_install directories venv_create venv_activate pip_upgrade dependencies env_file pre_commit db_init; do
         if [ "${COMPLETED_STEPS[$step]}" -eq 0 ]; then
             echo "   - ${STEP_DESCRIPTIONS[$step]}"
             has_remaining=1
@@ -212,6 +214,27 @@ else
 fi
 
 mark_completed "gh_workflow_peek"
+check_timeout
+
+# Install ai-aligned-git (git wrapper for AI safety)
+log_info "Checking for ai-aligned-git..."
+if [ ! -f "$HOME/.local/bin/git" ] || ! grep -q "AI-Aligned-Git" "$HOME/.local/bin/git" 2>/dev/null; then
+    log_info "Installing ai-aligned-git for AI-safe git operations..."
+    # Download and run the install script
+    curl -fsSL https://raw.githubusercontent.com/trieloff/ai-aligned-git/main/install.sh -o /tmp/install-ai-aligned-git.sh && \
+    chmod +x /tmp/install-ai-aligned-git.sh && \
+    bash /tmp/install-ai-aligned-git.sh -y || {
+        log_warning "Failed to install ai-aligned-git, continuing..."
+    }
+    rm -f /tmp/install-ai-aligned-git.sh
+
+    # Ensure ~/.local/bin is in PATH for this session
+    export PATH="$HOME/.local/bin:$PATH"
+else
+    log_info "ai-aligned-git is already installed"
+fi
+
+mark_completed "ai_aligned_git"
 check_timeout
 
 # Install uv if not present (it should be pre-installed in Terragon)


### PR DESCRIPTION
## Summary
- Integrates installation of `ai-aligned-git`, a git wrapper for AI-safe git operations, into the Terragon setup script
- Adds a new setup step `ai_aligned_git` to track installation progress
- Ensures `ai-aligned-git` is installed if not already present in the user's local bin
- Updates the setup script to include this step in the list of manual steps and completion tracking

## Changes

### terragon-setup.sh
- Added `ai_aligned_git` to `COMPLETED_STEPS` and `STEP_DESCRIPTIONS` associative arrays
- Included `ai_aligned_git` in the list of steps shown as remaining if not completed
- Implemented logic to check for existing `ai-aligned-git` installation by verifying the presence and content of `$HOME/.local/bin/git`
- Downloads and runs the official install script from the `ai-aligned-git` repository if not installed
- Adds `~/.local/bin` to the PATH for the current session to ensure the installed binary is accessible
- Marks the `ai_aligned_git` step as completed after installation

## Test plan
- Run `terragon-setup.sh` on a system without `ai-aligned-git` installed and verify it installs correctly
- Confirm the step is marked as completed and does not reinstall on subsequent runs
- Validate that the setup script lists `ai_aligned_git` as a remaining step if not installed
- Check that the PATH is updated to include `~/.local/bin` after installation

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6aac26f8-fe2f-4eff-acbe-93ecf466df7c