### PR TITLE
fix: ensure column utility is installed for gh-workflow-peek setup

### DIFF
--- a/terragon-setup.sh
+++ b/terragon-setup.sh
@@ -200,6 +200,24 @@ check_timeout
 # Install gh-workflow-peek GitHub CLI extension
 log_info "Checking for gh-workflow-peek extension..."
 if command -v gh &> /dev/null; then
+    # First ensure column utility is installed (required by gh-workflow-peek)
+    if ! command -v column &> /dev/null; then
+        log_info "Installing column utility (required by gh-workflow-peek)..."
+        if command -v apt-get &> /dev/null; then
+            sudo apt-get install -y bsdmainutils || sudo apt-get install -y util-linux || {
+                log_warning "Failed to install column utility via apt-get"
+            }
+        elif command -v yum &> /dev/null; then
+            sudo yum install -y util-linux || {
+                log_warning "Failed to install column utility via yum"
+            }
+        elif command -v brew &> /dev/null; then
+            brew install util-linux || {
+                log_warning "Failed to install column utility via brew"
+            }
+        fi
+    fi
+
     # Check if gh-workflow-peek is already installed
     if ! gh extension list | grep -q "trieloff/gh-workflow-peek"; then
         log_info "Installing gh-workflow-peek for CI/CD analysis..."


### PR DESCRIPTION
## Summary
- Adds installation checks for the `column` utility, which is required by the `gh-workflow-peek` GitHub CLI extension
- Supports installation via `apt-get`, `yum`, and `brew` package managers
- Logs warnings if installation of the `column` utility fails

## Changes

### terragon-setup.sh
- Before installing `gh-workflow-peek`, checks if the `column` command is available
- Attempts to install `column` using appropriate package managers depending on the environment:
  - `apt-get` installs `bsdmainutils` or `util-linux`
  - `yum` installs `util-linux`
  - `brew` installs `util-linux`
- Adds informative logging for installation steps and failure warnings

## Test plan
- [x] Run the setup script on systems without `column` installed and verify it installs the utility
- [x] Confirm that `gh-workflow-peek` installs successfully after `column` is available
- [x] Validate logging output for installation attempts and failures
- [x] Test on different OS environments with `apt-get`, `yum`, and `brew` available

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4bf9d234-5c87-48d2-9a19-89d8daf7e1a1