### PR TITLE
Add symlink creation for gh-workflow-peek in terragon-setup.sh

### DIFF
--- a/terragon-setup.sh
+++ b/terragon-setup.sh
@@ -227,6 +227,19 @@ if command -v gh &> /dev/null; then
     else
         log_info "gh-workflow-peek is already installed"
     fi
+
+    # Create symlink for gh-workflow-peek to make it available globally
+    GH_WORKFLOW_PEEK_PATH="$HOME/.local/share/gh/extensions/gh-workflow-peek/gh-workflow-peek"
+    if [ -f "$GH_WORKFLOW_PEEK_PATH" ]; then
+        log_info "Creating symlink for gh-workflow-peek..."
+        sudo ln -sf "$GH_WORKFLOW_PEEK_PATH" /usr/local/bin/gh-workflow-peek || {
+            log_warning "Failed to create symlink for gh-workflow-peek"
+        }
+        # Verify the symlink worked
+        if [ -L "/usr/local/bin/gh-workflow-peek" ]; then
+            log_success "gh-workflow-peek symlink created at /usr/local/bin/gh-workflow-peek"
+        fi
+    fi
 else
     log_warning "GitHub CLI (gh) not found, skipping gh-workflow-peek installation"
 fi


### PR DESCRIPTION
## Summary
- Enhances the `terragon-setup.sh` script to create a global symlink for the `gh-workflow-peek` GitHub CLI extension
- Ensures `gh-workflow-peek` is accessible from `/usr/local/bin` for easier usage
- Adds logging for symlink creation success or failure

## Changes

### terragon-setup.sh
- After installing `gh-workflow-peek`, checks if the extension binary exists in the user's local share directory
- Creates a symbolic link at `/usr/local/bin/gh-workflow-peek` pointing to the extension binary
- Uses `sudo ln -sf` to force the symlink creation
- Logs success or warning messages based on the outcome

## Test plan
- [x] Run `terragon-setup.sh` on a system with GitHub CLI installed
- [x] Verify that `gh-workflow-peek` is installed and the symlink `/usr/local/bin/gh-workflow-peek` is created
- [x] Confirm that running `gh-workflow-peek` from any terminal works as expected
- [x] Check logs for appropriate success or warning messages regarding symlink creation

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c315f004-5a38-4651-9a52-11c12f1bb819