### PR TITLE
Set Codecov coverage target to auto for project and patch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,11 +2,11 @@ coverage:
   status:
     project:
       default:
-        target: 100%
+        target: auto
         threshold: 0%
     patch:
       default:
-        target: 100%
+        target: auto
         threshold: 0%
 
 parsers:


### PR DESCRIPTION
## Summary
- Updated Codecov configuration to set coverage target to `auto` instead of a fixed 100%
- Applies to both project-wide and patch coverage targets

## Changes

### Codecov Configuration
- Modified `codecov.yml`:
  - Changed `coverage.status.project.default.target` from `100%` to `auto`
  - Changed `coverage.status.patch.default.target` from `100%` to `auto`

## Rationale
- Using `auto` allows Codecov to dynamically adjust coverage targets based on historical data
- Provides more realistic and achievable coverage goals

## Test plan
- Verify Codecov status checks reflect the updated `auto` target
- Confirm coverage reports and thresholds behave as expected with the new configuration

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/51da4df0-77ca-4cc1-8a4d-d46d3dd47282