### PR TITLE
Limit Claude reviews to new PRs with green checks

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,21 +1,44 @@
+# Claude Code Review Workflow
+#
+# This workflow runs Claude Code review on pull requests with two trigger mechanisms:
+# 1. Automatically when a new PR is opened (immediate feedback)
+# 2. After all CI checks pass (via workflow_run trigger)
+#
+# This ensures Claude reviews are:
+# - Provided early for new PRs
+# - Only run on green builds to avoid reviewing broken code
+# - Not triggered on every push (reducing noise)
+
 name: Claude Code Review
 
 on:
+  # Only run on new PRs
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
     #   - "src/**/*.tsx"
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
+  
+  # Also allow manual triggering after all checks pass
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: ["*"]
 
 jobs:
   claude-review:
     # Skip only for known problematic bots
+    # For workflow_run trigger, only run if the CI workflow succeeded
     if: |
-      github.event.pull_request.user.login != 'dependabot[bot]' &&
-      github.event.pull_request.user.login != 'renovate[bot]'
+      (github.event_name == 'pull_request' && 
+       github.event.pull_request.user.login != 'dependabot[bot]' &&
+       github.event.pull_request.user.login != 'renovate[bot]') ||
+      (github.event_name == 'workflow_run' && 
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'pull_request')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,13 +46,48 @@ jobs:
       issues: read
       id-token: write
     steps:
+      # Get PR information when triggered by workflow_run
+      - name: Get PR Information
+        if: github.event_name == 'workflow_run'
+        id: pr-info
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_TOKEN_FOR_CLAUDE }}
+          script: |
+            // Get the PR associated with this workflow run
+            const workflowRun = context.payload.workflow_run;
+            const headSha = workflowRun.head_sha;
+            
+            // Find PRs associated with this commit
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${workflowRun.head_repository.owner.login}:${workflowRun.head_branch}`
+            });
+            
+            if (prs.length === 0) {
+              console.log('No open PR found for this workflow run');
+              core.setOutput('skip', 'true');
+              return;
+            }
+            
+            const pr = prs[0];
+            core.setOutput('pr_number', pr.number);
+            core.setOutput('pr_head_ref', pr.head.ref);
+            core.setOutput('skip', 'false');
+
       - name: Checkout repository
+        if: github.event_name == 'pull_request' || steps.pr-info.outputs.skip != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
           token: ${{ secrets.GH_TOKEN_FOR_CLAUDE }}
+          # For workflow_run, checkout the PR branch
+          ref: ${{ github.event_name == 'workflow_run' && steps.pr-info.outputs.pr_head_ref || '' }}
 
       - name: Run Claude Code Review
+        if: github.event_name == 'pull_request' || steps.pr-info.outputs.skip != 'true'
         id: claude-review
         continue-on-error: true
         uses: anthropics/claude-code-action@beta
@@ -37,6 +95,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Use dedicated GitHub token for Claude to bypass OIDC issues
           github_token: ${{ secrets.GH_TOKEN_FOR_CLAUDE }}
+          # For workflow_run events, specify the PR number
+          pr_number: ${{ github.event_name == 'workflow_run' && steps.pr-info.outputs.pr_number || '' }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
@@ -55,12 +115,25 @@ jobs:
             please tag @terragon-labs in your review comment to ensure they are notified.
 
       - name: Report Claude Code Review Status
-        if: always()
+        if: always() && (github.event_name == 'pull_request' || steps.pr-info.outputs.skip != 'true')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_TOKEN_FOR_CLAUDE }}
           script: |
             const reviewOutcome = '${{ steps.claude-review.outcome }}';
+            
+            // Determine PR number based on event type
+            let prNumber;
+            if (context.eventName === 'pull_request') {
+              prNumber = context.issue.number;
+            } else if (context.eventName === 'workflow_run') {
+              prNumber = parseInt('${{ steps.pr-info.outputs.pr_number }}');
+            }
+            
+            if (!prNumber) {
+              console.log('Could not determine PR number, skipping comment');
+              return;
+            }
 
             if (reviewOutcome === 'failure') {
               const comment = [
@@ -79,7 +152,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: prNumber,
                 body: comment
               });
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ on:
     #   - "src/**/*.tsx"
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
-  
+
   # Also allow manual triggering after all checks pass
   workflow_run:
     workflows: ["CI"]
@@ -33,10 +33,10 @@ jobs:
     # Skip only for known problematic bots
     # For workflow_run trigger, only run if the CI workflow succeeded
     if: |
-      (github.event_name == 'pull_request' && 
+      (github.event_name == 'pull_request' &&
        github.event.pull_request.user.login != 'dependabot[bot]' &&
        github.event.pull_request.user.login != 'renovate[bot]') ||
-      (github.event_name == 'workflow_run' && 
+      (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'pull_request')
     runs-on: ubuntu-latest
@@ -57,7 +57,7 @@ jobs:
             // Get the PR associated with this workflow run
             const workflowRun = context.payload.workflow_run;
             const headSha = workflowRun.head_sha;
-            
+
             // Find PRs associated with this commit
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
@@ -65,13 +65,13 @@ jobs:
               state: 'open',
               head: `${workflowRun.head_repository.owner.login}:${workflowRun.head_branch}`
             });
-            
+
             if (prs.length === 0) {
               console.log('No open PR found for this workflow run');
               core.setOutput('skip', 'true');
               return;
             }
-            
+
             const pr = prs[0];
             core.setOutput('pr_number', pr.number);
             core.setOutput('pr_head_ref', pr.head.ref);
@@ -121,7 +121,7 @@ jobs:
           github-token: ${{ secrets.GH_TOKEN_FOR_CLAUDE }}
           script: |
             const reviewOutcome = '${{ steps.claude-review.outcome }}';
-            
+
             // Determine PR number based on event type
             let prNumber;
             if (context.eventName === 'pull_request') {
@@ -129,7 +129,7 @@ jobs:
             } else if (context.eventName === 'workflow_run') {
               prNumber = parseInt('${{ steps.pr-info.outputs.pr_number }}');
             }
-            
+
             if (!prNumber) {
               console.log('Could not determine PR number, skipping comment');
               return;


### PR DESCRIPTION
## Summary

This PR modifies the Claude Code review workflow to reduce noise and improve efficiency by:

- Only triggering reviews on newly opened PRs (not on every push)
- Adding a secondary trigger that runs reviews after all CI checks pass
- Ensuring high-quality code reviews while reducing reviewer fatigue

## Changes

1. **Modified trigger events**:
   - Changed from `[opened, synchronize]` to just `[opened]` for the pull_request event
   - Added `workflow_run` trigger that activates when the CI workflow completes successfully

2. **Added workflow_run handling**:
   - Extracts PR information when triggered by CI completion
   - Properly checks out the PR branch
   - Passes PR number to the Claude action

3. **Updated conditional logic**:
   - Ensures the workflow handles both event types correctly
   - Skips reviews for bot PRs (dependabot, renovate)
   - Only runs on successful CI builds when triggered by workflow_run

## Benefits

- **Reduced noise**: No more reviews on every single push
- **Better timing**: Reviews happen on new PRs (early feedback) and after CI passes (quality check)
- **Resource efficiency**: Fewer unnecessary review runs
- **Maintains quality**: Still ensures all code gets reviewed properly

## Test plan

- [ ] Create a new PR and verify Claude reviews it immediately
- [ ] Push additional commits and verify Claude doesn't review each push
- [ ] Wait for CI to pass and verify Claude reviews again
- [ ] Test with a failing CI build to ensure no review happens

🤖 Generated with [Claude Code](https://claude.ai/code)