### PR TITLE
feat(ci): Enable GitHub Models AI inference in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ permissions:
   pull-requests: write
   issues: write
   checks: write
+  models: read  # Enable GitHub Models for AI inference
 
 jobs:
   # Check if Python files were changed to determine if tests should run

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,6 +45,7 @@ jobs:
       pull-requests: write  # Changed from read to write for PR comments
       issues: read
       id-token: write
+      models: read  # Enable GitHub Models for AI inference
     steps:
       # Get PR information when triggered by workflow_run
       - name: Get PR Information

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,6 +24,7 @@ jobs:
       issues: write        # Changed from read to write for issue comments
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
+      models: read  # Enable GitHub Models for AI inference
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Added `models: read` permission to all GitHub Actions workflows
- Enables free AI inference capabilities through GitHub Models for open source projects
- Based on GitHub's announcement: https://github.blog/ai-and-ml/llms/solving-the-inference-problem-for-open-source-ai-projects-with-github-models/

## Changes
- Updated `.github/workflows/claude.yml` to include `models: read` permission
- Updated `.github/workflows/ci.yml` to include `models: read` permission  
- Updated `.github/workflows/claude-code-review.yml` to include `models: read` permission

## Test plan
- [ ] Verify workflows continue to run successfully with new permission
- [ ] Confirm no security issues with additional permission scope
- [ ] Test that workflows can access GitHub Models API when needed

## References
- [GitHub Blog: Solving the inference problem for open source AI projects](https://github.blog/ai-and-ml/llms/solving-the-inference-problem-for-open-source-ai-projects-with-github-models/)
- [GitHub Models Documentation](https://docs.github.com/en/github-models)

🤖 Generated with [Claude Code](https://claude.ai/code)