### PR TITLE
fix(ci): Replace unreliable workflow_run trigger with explicit workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,21 +445,27 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes, lint, type-check, security, test-canary, test-matrix, docs, build, pre-commit]
     if: always()
+    outputs:
+      all_passed: ${{ steps.check.outputs.all_passed }}
     steps:
       - name: Check if all jobs passed
+        id: check
         run: |
           # If no Python changes, automatically pass
           if [[ "${{ needs.changes.outputs.python }}" != "true" ]]; then
             echo "No Python files changed - skipping checks"
+            echo "all_passed=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           # Check for failures only if Python files were changed
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
             echo "One or more jobs failed"
+            echo "all_passed=false" >> $GITHUB_OUTPUT
             exit 1
           else
             echo "All jobs passed successfully"
+            echo "all_passed=true" >> $GITHUB_OUTPUT
           fi
 
   notify-terry:
@@ -540,6 +546,55 @@ jobs:
               issue_number: context.issue.number,
               body: comment
             });
+
+  trigger-post-ci:
+    name: Trigger Post-CI Actions
+    runs-on: ubuntu-latest
+    needs: [all-checks]
+    if: |
+      github.event_name == 'pull_request' &&
+      needs.all-checks.outputs.all_passed == 'true'
+    permissions:
+      actions: write
+      pull-requests: read
+    steps:
+      - name: Extract PR Information
+        id: pr-info
+        run: |
+          echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          echo "pr_head_ref=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
+          echo "pr_head_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+
+      - name: Trigger Post-CI Workflow
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = '${{ steps.pr-info.outputs.pr_number }}';
+            const prHeadRef = '${{ steps.pr-info.outputs.pr_head_ref }}';
+            const prHeadSha = '${{ steps.pr-info.outputs.pr_head_sha }}';
+
+            console.log(`Triggering post-CI actions for PR #${prNumber}`);
+
+            try {
+              const result = await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'post-ci.yml',
+                ref: prHeadRef,
+                inputs: {
+                  pr_number: prNumber,
+                  pr_head_ref: prHeadRef,
+                  pr_head_sha: prHeadSha,
+                  trigger_claude_review: 'true'
+                }
+              });
+
+              console.log('Successfully triggered post-CI workflow');
+            } catch (error) {
+              console.error('Failed to trigger post-CI workflow:', error);
+              // Don't fail the CI if we can't trigger post-CI actions
+            }
 
   vibe-badge:
     name: Generate Vibe Badge

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,13 +1,11 @@
 # Claude Code Review Workflow
 #
-# This workflow runs Claude Code review on pull requests with two trigger mechanisms:
+# This workflow runs Claude Code review on pull requests:
 # 1. Automatically when a new PR is opened (immediate feedback)
-# 2. After all CI checks pass (via workflow_run trigger)
+# 2. Can be triggered via workflow_dispatch for manual runs
 #
-# This ensures Claude reviews are:
-# - Provided early for new PRs
-# - Only run on green builds to avoid reviewing broken code
-# - Not triggered on every push (reducing noise)
+# Note: The post-CI.yml workflow now handles triggering Claude reviews
+# after successful CI runs using workflow_dispatch for better reliability.
 
 name: Claude Code Review
 
@@ -17,28 +15,24 @@ on:
     types: [opened]
     # Optional: Only run on specific file changes
     # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    #   - "src/**/*.py"
 
-  # Also allow manual triggering after all checks pass
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    branches: ["*"]
+  # Allow manual triggering
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull Request number to review'
+        required: false
+        type: string
 
 jobs:
   claude-review:
     # Skip only for known problematic bots
-    # For workflow_run trigger, only run if the CI workflow succeeded
     if: |
       (github.event_name == 'pull_request' &&
        github.event.pull_request.user.login != 'dependabot[bot]' &&
        github.event.pull_request.user.login != 'renovate[bot]') ||
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'pull_request')
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,33 +41,28 @@ jobs:
       id-token: write
       models: read  # Enable GitHub Models for AI inference
     steps:
-      # Get PR information when triggered by workflow_run
+      # Get PR information when triggered by workflow_dispatch
       - name: Get PR Information
-        if: github.event_name == 'workflow_run'
+        if: github.event_name == 'workflow_dispatch'
         id: pr-info
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_TOKEN_FOR_CLAUDE }}
           script: |
-            // Get the PR associated with this workflow run
-            const workflowRun = context.payload.workflow_run;
-            const headSha = workflowRun.head_sha;
-
-            // Find PRs associated with this commit
-            const { data: prs } = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              head: `${workflowRun.head_repository.owner.login}:${workflowRun.head_branch}`
-            });
-
-            if (prs.length === 0) {
-              console.log('No open PR found for this workflow run');
+            const prNumber = '${{ inputs.pr_number }}';
+            if (!prNumber) {
+              console.log('No PR number provided for workflow_dispatch');
               core.setOutput('skip', 'true');
               return;
             }
 
-            const pr = prs[0];
+            // Get the PR details
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: parseInt(prNumber)
+            });
+
             core.setOutput('pr_number', pr.number);
             core.setOutput('pr_head_ref', pr.head.ref);
             core.setOutput('skip', 'false');
@@ -84,8 +73,8 @@ jobs:
         with:
           fetch-depth: 1
           token: ${{ secrets.GH_TOKEN_FOR_CLAUDE }}
-          # For workflow_run, checkout the PR branch
-          ref: ${{ github.event_name == 'workflow_run' && steps.pr-info.outputs.pr_head_ref || '' }}
+          # For workflow_dispatch, checkout the PR branch
+          ref: ${{ github.event_name == 'workflow_dispatch' && steps.pr-info.outputs.pr_head_ref || '' }}
 
       - name: Run Claude Code Review
         if: github.event_name == 'pull_request' || steps.pr-info.outputs.skip != 'true'
@@ -96,8 +85,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Use dedicated GitHub token for Claude to bypass OIDC issues
           github_token: ${{ secrets.GH_TOKEN_FOR_CLAUDE }}
-          # For workflow_run events, specify the PR number
-          pr_number: ${{ github.event_name == 'workflow_run' && steps.pr-info.outputs.pr_number || '' }}
+          # For workflow_dispatch events, specify the PR number
+          pr_number: ${{ github.event_name == 'workflow_dispatch' && steps.pr-info.outputs.pr_number || '' }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
@@ -127,7 +116,7 @@ jobs:
             let prNumber;
             if (context.eventName === 'pull_request') {
               prNumber = context.issue.number;
-            } else if (context.eventName === 'workflow_run') {
+            } else if (context.eventName === 'workflow_dispatch') {
               prNumber = parseInt('${{ steps.pr-info.outputs.pr_number }}');
             }
 

--- a/.github/workflows/post-ci.yml
+++ b/.github/workflows/post-ci.yml
@@ -1,0 +1,187 @@
+# Post-CI Actions Workflow
+#
+# This workflow is triggered after successful CI runs to perform additional
+# actions like Claude Code Review and other post-build tasks.
+# Using workflow_dispatch for more reliable triggering than workflow_run.
+
+name: Post-CI Actions
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull Request number'
+        required: true
+        type: string
+      pr_head_ref:
+        description: 'Pull Request head branch'
+        required: true
+        type: string
+      pr_head_sha:
+        description: 'Pull Request head SHA'
+        required: true
+        type: string
+      trigger_claude_review:
+        description: 'Trigger Claude Code Review'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  checks: write
+  models: read  # Enable GitHub Models for AI inference
+
+jobs:
+  claude-review:
+    name: Claude Code Review
+    if: inputs.trigger_claude_review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      models: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.GH_TOKEN_FOR_CLAUDE }}
+          ref: ${{ inputs.pr_head_ref }}
+
+      - name: Run Claude Code Review
+        id: claude-review
+        continue-on-error: true
+        uses: anthropics/claude-code-action@beta
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GH_TOKEN_FOR_CLAUDE }}
+          pr_number: ${{ inputs.pr_number }}
+          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
+          # model: "claude-opus-4-20250514"
+          direct_prompt: |
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Be constructive and helpful in your feedback.
+
+            IMPORTANT: If you identify any issues that need to be addressed or improvements that should be made,
+            please tag @terragon-labs in your review comment to ensure they are notified.
+
+      - name: Report Claude Code Review Status
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_TOKEN_FOR_CLAUDE }}
+          script: |
+            const reviewOutcome = '${{ steps.claude-review.outcome }}';
+            const prNumber = parseInt('${{ inputs.pr_number }}');
+
+            if (reviewOutcome === 'failure') {
+              const comment = [
+                '🤖 **Claude Code Review Notice**',
+                '',
+                '⚠️ The Claude Code review could not be completed due to a known issue.',
+                '',
+                'This is related to: https://github.com/anthropics/claude-code-action/issues/351',
+                '',
+                'The review failure does not indicate any problems with your code. This workflow step will continue to fail until the upstream issue is resolved.',
+                '',
+                '---',
+                '_This is an automated message triggered after successful CI checks._'
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: comment
+              });
+
+              console.log('Claude Code Review failed - known upstream issue');
+            } else if (reviewOutcome === 'success') {
+              console.log('Claude Code Review completed successfully');
+
+              // Post success notification
+              const comment = [
+                '✅ **CI Checks Passed & Claude Review Complete**',
+                '',
+                'All CI checks have passed successfully! Claude has completed its code review.',
+                '',
+                'Please check the review comments above for any suggestions or improvements.',
+                '',
+                '---',
+                '_Automated post-CI notification_'
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: comment
+              });
+            } else {
+              console.log(`Claude Code Review outcome: ${reviewOutcome}`);
+            }
+
+  notify-success:
+    name: Notify Success
+    runs-on: ubuntu-latest
+    needs: [claude-review]
+    if: |
+      always() &&
+      !contains(needs.*.result, 'failure')
+    steps:
+      - name: Post Success Summary
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = parseInt('${{ inputs.pr_number }}');
+            const claudeReviewStatus = '${{ needs.claude-review.result }}';
+
+            console.log(`Post-CI actions completed. Claude Review: ${claudeReviewStatus}`);
+
+            // Check if this PR has a Terry task
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            const hasTerragonTask = pr.body && pr.body.includes('terragonlabs.com/task');
+
+            if (hasTerragonTask) {
+              // Extract task URL for notification
+              const taskUrlMatch = pr.body.match(/https:\/\/www\.terragonlabs\.com\/task\/[a-f0-9-]+/);
+              const taskUrl = taskUrlMatch ? taskUrlMatch[0] : null;
+
+              if (taskUrl) {
+                const comment = [
+                  '🎉 **All Checks Complete!**',
+                  '',
+                  '✅ CI checks passed',
+                  claudeReviewStatus === 'success' ? '✅ Claude Code Review completed' : '⚠️ Claude Code Review skipped or failed (non-blocking)',
+                  '',
+                  '@terragon-labs - This PR is ready for your review!',
+                  `- [Terry Task](${taskUrl})`,
+                  '',
+                  '_All automated checks have completed successfully._'
+                ].join('\n');
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: comment
+                });
+              }
+            }


### PR DESCRIPTION
## Summary

- Replace unreliable `workflow_run` trigger with explicit `workflow_dispatch` for Claude Code Review
- Create new `post-ci.yml` workflow to handle all post-CI actions
- Update CI workflow to trigger post-CI actions when all checks pass

## Problem

The `workflow_run` trigger for Claude Code Review was not reliably firing when CI workflows completed successfully. For example, in PR #172, the CI completed successfully but the Claude Code Review workflow never triggered.

## Solution

Instead of relying on the `workflow_run` event, we now:
1. Use a new `post-ci.yml` workflow that handles all post-CI actions
2. Explicitly trigger this workflow from the CI workflow using `workflow_dispatch`
3. This gives us better control and visibility over when reviews are triggered

## Changes

### New `post-ci.yml` workflow
- Triggered via `workflow_dispatch` with PR details as inputs
- Runs Claude Code Review on successful CI builds
- Notifies Terragon Labs when all checks complete

### Updated `ci.yml`
- Added `trigger-post-ci` job that runs after all checks pass
- Uses GitHub API to trigger the post-CI workflow with PR information

### Updated `claude-code-review.yml`
- Removed unreliable `workflow_run` trigger
- Added support for `workflow_dispatch` as alternative trigger method
- Kept `pull_request` opened trigger for immediate feedback on new PRs

## Test Plan

This PR itself will test the new workflow configuration:
1. [ ] CI checks should pass
2. [ ] The `trigger-post-ci` job should appear in the CI workflow
3. [ ] A new `Post-CI Actions` workflow should be triggered
4. [ ] Claude Code Review should run from the post-CI workflow