### PR TITLE
Fix capitalization inconsistencies in integration test script

### DIFF
--- a/tests/fixtures/fountain/test_data/props_test_script.fountain
+++ b/tests/fixtures/fountain/test_data/props_test_script.fountain
@@ -6,48 +6,48 @@ Draft date: 2024-01-01
 
 INT. DETECTIVE'S OFFICE - NIGHT
 
-A dimly lit office. DETECTIVE MILLER (45, weathered) sits behind a cluttered desk covered with case files and photographs. A half-empty WHISKEY BOTTLE and GLASS sit nearby.
+A dimly lit office. DETECTIVE MILLER (45, weathered) sits behind a cluttered desk covered with case files and photographs. A half-empty whiskey bottle and glass sit nearby.
 
-He picks up his REVOLVER, checks the cylinder, and places it in his shoulder holster. His BADGE gleams under the desk lamp.
+He picks up his revolver, checks the cylinder, and places it in his shoulder holster. His badge gleams under the desk lamp.
 
 DETECTIVE MILLER
 (into phone)
 Yeah, I got the photos. The murder weapon was definitely a knife.
 
-He hangs up the old rotary PHONE and lights a CIGARETTE with his silver LIGHTER.
+He hangs up the old rotary phone and lights a cigarette with his silver lighter.
 
-The door opens. SARAH (30s) enters carrying a leather BRIEFCASE.
+The door opens. SARAH (30s) enters carrying a leather briefcase.
 
 SARAH
 I brought the money. Fifty thousand in cash, as promised.
 
-She opens the briefcase revealing stacks of HUNDRED DOLLAR BILLS.
+She opens the briefcase revealing stacks of hundred dollar bills.
 
 DETECTIVE MILLER
 And the documents?
 
-Sarah pulls out a manila ENVELOPE from her coat.
+Sarah pulls out a manila envelope from her coat.
 
 SARAH
-Everything's here. Bank records, surveillance footage on this USB DRIVE.
+Everything's here. Bank records, surveillance footage on this usb drive.
 (hands him the drive)
 And your plane ticket to Mexico.
 
-Miller takes a swig from his whiskey glass, then puts on his fedora HAT and TRENCH COAT.
+Miller takes a swig from his whiskey glass, then puts on his fedora hat and trench coat.
 
 DETECTIVE MILLER
-(checking his WATCH)
+(checking his watch)
 We need to go. Take the car keys.
 
-He tosses her his CAR KEYS and grabs the briefcase.
+He tosses her his car keys and grabs the briefcase.
 
 EXT. PARKING LOT - CONTINUOUS
 
-Rain pours down. Miller and Sarah run to a vintage MUSTANG. Sarah gets in the driver's seat while Miller loads the briefcase in the trunk next to a SHOTGUN and a FIRST AID KIT.
+Rain pours down. Miller and Sarah run to a vintage Mustang. Sarah gets in the driver's seat while Miller loads the briefcase in the trunk next to a shotgun and a first aid kit.
 
 INT. MUSTANG - CONTINUOUS
 
-Sarah starts the engine. The radio plays jazz. Miller checks his CELLPHONE - three missed calls.
+Sarah starts the engine. The radio plays jazz. Miller checks his cellphone - three missed calls.
 
 SARAH
 (nervous)
@@ -56,14 +56,14 @@ What about the paintings in the safe?
 DETECTIVE MILLER
 Leave them. We only need the diamonds.
 
-He pulls out a small velvet POUCH from his pocket, revealing several DIAMONDS.
+He pulls out a small velvet pouch from his pocket, revealing several diamonds.
 
 SARAH
 And the security cameras?
 
 DETECTIVE MILLER
 Disabled them with my laptop.
-(shows her a LAPTOP)
+(shows her a laptop)
 Wiped everything.
 
 Sarah accelerates, tires screeching. In the rearview mirror, police lights flash.


### PR DESCRIPTION
## Summary
- Corrects inconsistent capitalization of common nouns and objects in the integration test script
- Improves readability and consistency in the test fixture script used for fountain format testing

## Changes

### Test Data Update
- Modified `tests/fixtures/fountain/test_data/props_test_script.fountain` to use lowercase for general objects and items (e.g., "whiskey bottle", "revolver", "badge") instead of uppercase
- Ensured proper nouns and character names remain capitalized while common nouns are lowercase

## Test plan
- Verified that the updated script maintains the intended narrative and formatting
- Confirmed that integration tests using this fixture run without errors and reflect the corrected capitalization

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/dc8f7d02-5a92-4650-8750-8b0b594a5a6d