### PR TITLE
Add brittle mode to stop processing on analyzer failures

### DIFF
--- a/src/scriptrag/cli/commands/analyze.py
+++ b/src/scriptrag/cli/commands/analyze.py
@@ -48,6 +48,13 @@ def analyze_command(
             help="Additional analyzers to run (can be specified multiple times)",
         ),
     ] = None,
+    brittle: Annotated[
+        bool,
+        typer.Option(
+            "--brittle",
+            help="Stop processing if any analyzer fails (default: skip failed)",
+        ),
+    ] = False,
 ) -> None:
     """Analyze Fountain files and update their metadata.
 
@@ -94,6 +101,7 @@ def analyze_command(
                     recursive=not no_recursive,
                     force=force,
                     dry_run=dry_run,
+                    brittle=brittle,
                     progress_callback=update_progress,
                 )
             )

--- a/src/scriptrag/cli/commands/pull.py
+++ b/src/scriptrag/cli/commands/pull.py
@@ -61,6 +61,13 @@ def pull_command(
             help="Path to configuration file (YAML, TOML, or JSON)",
         ),
     ] = None,
+    brittle: Annotated[
+        bool,
+        typer.Option(
+            "--brittle",
+            help="Stop processing if any analyzer fails (default: skip failed)",
+        ),
+    ] = False,
 ) -> None:
     """Pull fountain files into the database (init + analyze + index).
 
@@ -119,6 +126,7 @@ def pull_command(
                     recursive=not no_recursive,
                     force=force,
                     dry_run=dry_run,
+                    brittle=brittle,
                     progress_callback=analyze_progress,
                 )
             )


### PR DESCRIPTION
## Summary
- Introduces a new `brittle` mode option to the analyze and pull commands
- When enabled, processing stops immediately if any analyzer fails
- Default behavior remains to skip failed analyzers and continue processing

## Changes

### Core Functionality
- Added `brittle` boolean parameter to `AnalyzeCommand.analyze` and `AnalyzeCommand._process_file` methods
- Updated error handling to raise exceptions and stop processing when `brittle` is `True`
- Logged errors differently in brittle mode to indicate immediate stop

### CLI Commands
- Added `--brittle` option to `analyze` and `pull` CLI commands
- Passed `brittle` flag down to the analyze operation to control failure behavior

## Test plan
- Verify that analyze and pull commands run successfully with and without `--brittle`
- Confirm that with `--brittle`, the process stops on first analyzer failure
- Confirm that without `--brittle`, failures are logged as warnings and processing continues
- Check logs for appropriate error messages in brittle mode
- Run existing tests to ensure no regressions in analyze functionality

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/549223ab-00ad-4056-9703-a436d432cabb