### PR TITLE
Fix test fixture contamination and improve test isolation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,14 @@ test: install ## Run all tests in parallel with coverage
 		find . \( -name "*Mock*name=*" -o -name "<Mock*" -o -name "*<Mock*" -o -name "*id='\''*'\''*" \) -not -path "*/.git/*" -not -path "*/__pycache__/*" 2>/dev/null; \
 		exit 1; \
 	fi'
+	@echo "🔍 Checking fixture files are clean..."
+	@bash -c 'for f in tests/fixtures/fountain/test_data/{coffee_shop,simple_script,test_script,nested_script,parser_test}.fountain; do \
+		if grep -q "SCRIPTRAG-META-START" "$$f" 2>/dev/null; then \
+			echo "❌ ERROR: Fixture file $$f is contaminated with metadata!"; \
+			echo "Run '\''git checkout $$f'\'' to restore it."; \
+			exit 1; \
+		fi; \
+	done'
 	uv run pytest tests/ -v -n auto --cov=scriptrag --cov-report= --junit-xml=junit.xml $(PYTEST_ARGS)
 	uv run coverage combine || true  # May already be combined by pytest-xdist
 	uv run coverage xml
@@ -171,6 +179,14 @@ test-fast: install ## Run tests without coverage (faster)
 		echo "Run '\''make clean-mock-files'\'' to remove them."; \
 		exit 1; \
 	fi'
+	@echo "🔍 Checking fixture files are clean..."
+	@bash -c 'for f in tests/fixtures/fountain/test_data/{coffee_shop,simple_script,test_script,nested_script,parser_test}.fountain; do \
+		if grep -q "SCRIPTRAG-META-START" "$$f" 2>/dev/null; then \
+			echo "❌ ERROR: Fixture file $$f is contaminated with metadata!"; \
+			echo "Run '\''git checkout $$f'\'' to restore it."; \
+			exit 1; \
+		fi; \
+	done'
 	uv run pytest tests/ -v -n auto
 	@echo "🔍 Checking for mock files after tests..."
 	@bash -c 'if find . \( -name "*Mock*name=*" -o -name "<Mock*" -o -name "*<Mock*" -o -name "*id='\''*'\''*" \) -not -path "*/.git/*" -not -path "*/__pycache__/*" 2>/dev/null | head -1 | grep -q .; then \

--- a/tests/integration/test_context_query.py
+++ b/tests/integration/test_context_query.py
@@ -27,17 +27,23 @@ def clean_settings():
 
 
 @pytest.fixture
-def multi_scene_screenplay():
-    """Load the multi-scene screenplay fixture with proper prop capitalization."""
-    # Use the screenplay from fixtures directory with correct capitalization
-    # (only CHARACTER names are capitalized, not props)
-    return (
+def multi_scene_screenplay(tmp_path):
+    """Copy the multi-scene screenplay fixture to temp directory."""
+    import shutil
+
+    # Source file from fixtures directory
+    source_file = (
         Path(__file__).parent.parent
         / "fixtures"
         / "fountain"
         / "test_data"
         / "props_context_multi_scene.fountain"
     )
+
+    # Copy to temp directory to avoid contaminating fixtures
+    dest_file = tmp_path / "props_context_multi_scene.fountain"
+    shutil.copy2(source_file, dest_file)
+    return dest_file
 
 
 @pytest.mark.requires_llm


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where tests were directly modifying fixture files, causing test failures and blocking CI/CD pipelines.

## Changes

- Fixed `test_context_query.py` to copy fixtures to temp directory instead of modifying originals
- Added fixture contamination checks to Makefile test targets  
- Restored contaminated `coffee_shop.fountain` fixtures to original state
- Enhanced test isolation to prevent future fixture contamination

## Problem

Tests were directly using fixture file paths instead of copying them to temporary directories. When tests ran the `analyze` command, it would write metadata back to the original fixture files, contaminating them for future test runs.

## Solution  

1. Updated test fixtures to always copy files to temp directories before use
2. Added pre-test checks in Makefile to detect contaminated fixtures
3. Clear error messages guide developers to fix contamination issues

## Testing

- All tests now pass without modifying fixture files
- Fixture contamination is detected and prevented
- CI/CD pipeline no longer blocked by contaminated fixtures