### PR TITLE
Add test-coverage target to Makefile for detailed coverage reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,18 @@ coverage-combine: install ## Combine coverage data from parallel test runs
 	uv run coverage html
 	@echo "✅ Combined coverage report generated in htmlcov/"
 
+.PHONY: test-coverage
+test-coverage: test ## Run tests and print detailed coverage report
+	@echo ""
+	@echo "📊 Detailed Coverage Report"
+	@echo "==========================="
+	uv run coverage report --show-missing --skip-covered --skip-empty --sort=cover
+	@echo ""
+	@echo "📈 Coverage Summary:"
+	uv run coverage report --format=total
+	@echo ""
+	@echo "📁 HTML report available in htmlcov/index.html"
+
 # Documentation
 .PHONY: docs
 docs: install ## Build documentation


### PR DESCRIPTION
## Summary
- Introduces a new `test-coverage` Makefile target
- Runs tests and prints a detailed coverage report in the terminal
- Provides a summary of coverage and points to the HTML report

## Changes

### Makefile
- Added `.PHONY: test-coverage` target
- `test-coverage` runs tests and then:
  - Prints a detailed coverage report showing missing lines, skipping fully covered and empty files
  - Displays a coverage summary in total format
  - Reminds users that an HTML coverage report is available in `htmlcov/index.html`

## Test plan
- [x] Run `make test-coverage` to verify tests execute and coverage reports are printed
- [x] Confirm detailed coverage output and summary appear as expected
- [x] Check that HTML coverage report is generated and accessible

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/83926cdb-d4eb-46a9-adac-aa25a78f8af1