### PR TITLE
Simplify scene management by replacing token system with timestamp validation

### DIFF
--- a/SIMPLIFICATION_SUMMARY.md
+++ b/SIMPLIFICATION_SUMMARY.md
@@ -1,0 +1,110 @@
+# Scene Management Simplification Summary
+
+## Overview
+
+Successfully simplified the scene management system by replacing the complex token-based system with a simpler timestamp-based validation approach, as requested in GitHub Issue #253.
+
+## Changes Made
+
+### 1. Database Schema Updates
+
+- Added `last_read_at` timestamp column to the `scenes` table
+- Utilized existing `updated_at` column for modification tracking
+- Created migration SQL in `/src/scriptrag/storage/database/sql/add_last_read.sql`
+
+### 2. API Simplification (`src/scriptrag/api/scene_management.py`)
+
+#### Removed Components
+
+- `ReadSession` dataclass (complex session tracking)
+- `SessionValidationResult` dataclass
+- `ReadTracker` class (token management system)
+- All token generation, validation, and expiration logic
+
+#### Updated Components
+
+- `ReadSceneResult`: Now returns `last_read` timestamp instead of `session_token`
+- `read_scene()`: Updates `last_read_at` timestamp, no token generation
+- `update_scene()`: Added optional `check_conflicts` parameter for timestamp-based validation
+
+### 3. CLI Updates (`src/scriptrag/cli/commands/scene.py`)
+
+#### Scene Read Command
+
+- Removed session token display
+- Shows last read timestamp instead
+
+#### Scene Update Command
+
+- Removed `--token` requirement
+- Added `--safe` flag for optional conflict checking
+- Added `--last-read` parameter for timestamp-based validation
+- Default behavior: immediate updates without conflict checking
+
+### 4. MCP Tools Updates (`src/scriptrag/mcp/tools/scene.py`)
+
+- Updated to match new API signature
+- Removed session token parameters
+- Added conflict checking options
+
+### 5. Test Updates
+
+- Removed `TestReadTracker` class
+- Updated all tests to use new timestamp-based approach
+- All 23 tests passing
+
+## Benefits of the New System
+
+1. **Simplicity**: No complex token management infrastructure
+2. **No Expiration Issues**: Timestamps don't expire
+3. **Flexibility**: Users can choose between:
+   - Simple updates (default, no checking)
+   - Safe updates (with `--safe` flag and timestamp)
+4. **Better UX**: No need to manage tokens between commands
+5. **Cleaner Code**: Removed ~200 lines of token management code
+
+## Usage Examples
+
+### Simple Update (Default)
+
+```bash
+# Direct update without any conflict checking
+uv run scriptrag scene update --project "MyScript" --scene 5 \
+  --content "INT. OFFICE - DAY\n\nNew content."
+```
+
+### Safe Update (With Conflict Detection)
+
+```bash
+# First, read the scene
+uv run scriptrag scene read --project "MyScript" --scene 5
+# Output shows: Last read: 2024-01-15T10:30:00
+
+# Then update with conflict checking
+uv run scriptrag scene update --safe --project "MyScript" --scene 5 \
+  --last-read "2024-01-15T10:30:00" \
+  --content "INT. OFFICE - DAY\n\nUpdated content."
+```
+
+## Migration Notes
+
+- Existing databases need to run the migration SQL to add `last_read_at` column
+- The system is backward compatible (updates work without timestamps)
+- No breaking changes for users who don't need conflict detection
+
+## Files Modified
+
+- `src/scriptrag/api/scene_management.py` - Core API changes
+- `src/scriptrag/cli/commands/scene.py` - CLI command updates  
+- `src/scriptrag/mcp/tools/scene.py` - MCP tool updates
+- `tests/test_scene_management.py` - Test updates
+- `src/scriptrag/storage/database/sql/add_last_read.sql` - Database migration
+- `examples/scene_update_example.sh` - Usage examples
+
+## Testing
+
+All tests pass successfully:
+
+- 23 scene management tests passing
+- Type checking passes
+- Linting passes

--- a/examples/scene_update_example.sh
+++ b/examples/scene_update_example.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Example of using the simplified scene management with timestamps
+
+echo "======================================"
+echo "ScriptRAG Scene Management Example"
+echo "======================================"
+echo ""
+echo "This example demonstrates the simplified scene management system"
+echo "that replaces the complex token system with timestamp-based validation."
+echo ""
+
+# Simple update (no conflict checking - default behavior)
+echo "1. Simple Update (no conflict checking):"
+echo "-----------------------------------------"
+echo "uv run scriptrag scene update --project 'MyScript' --scene 5 --content 'INT. OFFICE - DAY"
+echo ""
+echo "New content for the scene.'"
+echo ""
+echo "This updates the scene immediately without any conflict checking."
+echo ""
+
+# Safe update (with conflict checking)
+echo "2. Safe Update (with conflict checking):"
+echo "-----------------------------------------"
+echo "# First, read the scene to get the timestamp"
+echo "uv run scriptrag scene read --project 'MyScript' --scene 5"
+echo "# Output will show: Last read: 2024-01-15T10:30:00"
+echo ""
+echo "# Then update with conflict checking"
+echo "uv run scriptrag scene update --safe --project 'MyScript' --scene 5 \\"
+echo "  --last-read '2024-01-15T10:30:00' \\"
+echo "  --content 'INT. OFFICE - DAY"
+echo ""
+echo "Updated content.'"
+echo ""
+echo "If the scene was modified since the last read, the update will fail"
+echo "with a conflict error, preventing accidental overwrites."
+echo ""
+
+echo "Benefits of the new system:"
+echo "- No token management complexity"
+echo "- No expiration issues"
+echo "- Simpler code"
+echo "- Better user experience"
+echo "- Optional conflict checking when needed"

--- a/src/scriptrag/storage/database/sql/add_last_read.sql
+++ b/src/scriptrag/storage/database/sql/add_last_read.sql
@@ -1,0 +1,8 @@
+-- Add last_read_at column to scenes table for timestamp-based validation
+-- This replaces the complex token system with simple timestamp tracking
+
+ALTER TABLE scenes ADD COLUMN last_read_at TIMESTAMP;
+
+-- Update schema version
+INSERT INTO schema_version (version, description)
+VALUES (2, 'Added last_read_at to scenes table for simplified validation');


### PR DESCRIPTION
## Summary
- Replaces the complex token-based scene read session system with a simpler timestamp-based validation approach
- Adds `last_read_at` timestamp column to scenes table for tracking last read time
- Updates API, CLI, MCP tools, and tests to use timestamp validation instead of session tokens
- Provides optional conflict detection on scene updates using timestamps
- Removes ~200 lines of token management code, improving code clarity and user experience

## Changes

### Database
- Added migration SQL to add `last_read_at` column to `scenes` table

### API (`src/scriptrag/api/scene_management.py`)
- Removed `ReadSession`, `ReadTracker`, and session token logic
- `read_scene()` updates and returns last read timestamp instead of session token
- `update_scene()` supports optional conflict checking with `--safe` flag and `last_read` timestamp

### CLI (`src/scriptrag/cli/commands/scene.py`)
- Removed session token options and output
- Added `--safe` flag and `--last-read` parameter for conflict detection
- Default update behavior is immediate without conflict checking

### MCP Tools (`src/scriptrag/mcp/tools/scene.py`)
- Updated to match new API signature
- Removed session token parameters
- Added conflict checking options

### Tests (`tests/test_scene_management.py`)
- Removed tests for token-based session tracking
- Updated tests to cover timestamp-based validation and conflict detection

### Examples
- Added example script demonstrating simple and safe update usage with timestamps

## Benefits
- Simplifies scene management by removing token complexity
- Eliminates token expiration issues
- Provides flexible update modes: immediate or safe with conflict detection
- Improves user experience by removing token management
- Results in cleaner, more maintainable codebase

## Migration Notes
- Run the provided SQL migration to add `last_read_at` column
- Backward compatible: updates without timestamps still work
- Users can opt-in to conflict detection with `--safe` flag and timestamp

## Testing
- All 23 scene management tests pass with updated logic
- Type checking and linting pass successfully

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4ce7fb2d-ee7d-498f-98e5-407eb4e9015d