### PR TITLE
Add explicit return type annotations to constructors

### DIFF
--- a/src/scriptrag/agents/context_query.py
+++ b/src/scriptrag/agents/context_query.py
@@ -151,7 +151,7 @@ class ContextParameters:
 class ContextQueryExecutor:
     """Executes context queries for agents."""
 
-    def __init__(self, settings: ScriptRAGSettings | None = None):
+    def __init__(self, settings: ScriptRAGSettings | None = None) -> None:
         """Initialize the executor.
 
         Args:

--- a/src/scriptrag/analyzers/base.py
+++ b/src/scriptrag/analyzers/base.py
@@ -11,7 +11,7 @@ class BaseSceneAnalyzer(ABC):
     additional metadata from scenes beyond the basic extraction.
     """
 
-    def __init__(self, config: dict[str, Any] | None = None):
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
         """Initialize analyzer.
 
         Args:

--- a/src/scriptrag/api/analyze.py
+++ b/src/scriptrag/api/analyze.py
@@ -63,7 +63,7 @@ class AnalyzeCommand:
     def __init__(
         self,
         analyzers: list[SceneAnalyzer | Any] | None = None,
-    ):
+    ) -> None:
         """Initialize analyze command.
 
         Args:

--- a/src/scriptrag/api/bible_index.py
+++ b/src/scriptrag/api/bible_index.py
@@ -37,7 +37,7 @@ class BibleIndexer:
         self,
         settings: ScriptRAGSettings | None = None,
         db_ops: DatabaseOperations | None = None,
-    ):
+    ) -> None:
         """Initialize bible indexer.
 
         Args:

--- a/src/scriptrag/api/database_operations.py
+++ b/src/scriptrag/api/database_operations.py
@@ -31,7 +31,7 @@ class ScriptRecord:
 class DatabaseOperations:
     """Handles all database operations for indexing."""
 
-    def __init__(self, settings: ScriptRAGSettings):
+    def __init__(self, settings: ScriptRAGSettings) -> None:
         """Initialize database operations with settings.
 
         Args:

--- a/src/scriptrag/api/index.py
+++ b/src/scriptrag/api/index.py
@@ -73,7 +73,7 @@ class IndexCommand:
         self,
         settings: ScriptRAGSettings | None = None,
         db_ops: DatabaseOperations | None = None,
-    ):
+    ) -> None:
         """Initialize index command.
 
         Args:

--- a/src/scriptrag/api/query.py
+++ b/src/scriptrag/api/query.py
@@ -11,7 +11,7 @@ logger = get_logger(__name__)
 class QueryAPI:
     """High-level API for query operations."""
 
-    def __init__(self, settings: ScriptRAGSettings | None = None):
+    def __init__(self, settings: ScriptRAGSettings | None = None) -> None:
         """Initialize query API.
 
         Args:

--- a/src/scriptrag/api/scene_management.py
+++ b/src/scriptrag/api/scene_management.py
@@ -24,7 +24,7 @@ logger = get_logger(__name__)
 class SceneManagementAPI:
     """AI-friendly scene management interface."""
 
-    def __init__(self, settings: ScriptRAGSettings | None = None):
+    def __init__(self, settings: ScriptRAGSettings | None = None) -> None:
         """Initialize the API.
 
         Args:

--- a/src/scriptrag/api/search.py
+++ b/src/scriptrag/api/search.py
@@ -11,7 +11,7 @@ logger = get_logger(__name__)
 class SearchAPI:
     """Main API for search functionality."""
 
-    def __init__(self, settings: ScriptRAGSettings | None = None):
+    def __init__(self, settings: ScriptRAGSettings | None = None) -> None:
         """Initialize search API.
 
         Args:

--- a/src/scriptrag/common/file_source.py
+++ b/src/scriptrag/common/file_source.py
@@ -32,7 +32,7 @@ class FileSourceResolver:
         env_var: str | None = None,
         default_subdir: str | None = None,
         file_extension: str = "*",
-    ):
+    ) -> None:
         """Initialize the file source resolver.
 
         Args:

--- a/src/scriptrag/llm/model_discovery.py
+++ b/src/scriptrag/llm/model_discovery.py
@@ -336,7 +336,9 @@ class ClaudeCodeModelDiscovery(ModelDiscovery):
             logger.debug(f"Failed to fetch models from Anthropic API: {e}")
             return None
 
-    def _parse_anthropic_models(self, models_data: list[dict]) -> list[Model] | None:
+    def _parse_anthropic_models(
+        self, models_data: list[dict[str, Any]]
+    ) -> list[Model] | None:
         """Parse model data from Anthropic API into Model objects.
 
         Args:

--- a/src/scriptrag/query/engine.py
+++ b/src/scriptrag/query/engine.py
@@ -14,7 +14,7 @@ logger = get_logger(__name__)
 class QueryEngine:
     """Execute SQL queries with parameter binding."""
 
-    def __init__(self, settings: ScriptRAGSettings | None = None):
+    def __init__(self, settings: ScriptRAGSettings | None = None) -> None:
         """Initialize query engine.
 
         Args:

--- a/src/scriptrag/query/formatter.py
+++ b/src/scriptrag/query/formatter.py
@@ -16,7 +16,7 @@ logger = get_logger(__name__)
 class QueryFormatter:
     """Format query results for display."""
 
-    def __init__(self, console: Console | None = None):
+    def __init__(self, console: Console | None = None) -> None:
         """Initialize formatter.
 
         Args:

--- a/src/scriptrag/query/loader.py
+++ b/src/scriptrag/query/loader.py
@@ -13,7 +13,7 @@ logger = get_logger(__name__)
 class QueryLoader:
     """Load and manage SQL query specifications."""
 
-    def __init__(self, settings: ScriptRAGSettings | None = None):
+    def __init__(self, settings: ScriptRAGSettings | None = None) -> None:
         """Initialize query loader.
 
         Args:

--- a/src/scriptrag/search/engine.py
+++ b/src/scriptrag/search/engine.py
@@ -25,7 +25,7 @@ logger = get_logger(__name__)
 class SearchEngine:
     """Execute search queries against the database."""
 
-    def __init__(self, settings: ScriptRAGSettings | None = None):
+    def __init__(self, settings: ScriptRAGSettings | None = None) -> None:
         """Initialize search engine.
 
         Args:

--- a/src/scriptrag/search/formatter.py
+++ b/src/scriptrag/search/formatter.py
@@ -15,7 +15,7 @@ logger = get_logger(__name__)
 class ResultFormatter:
     """Format search results for display."""
 
-    def __init__(self, console: Console | None = None):
+    def __init__(self, console: Console | None = None) -> None:
         """Initialize formatter.
 
         Args:

--- a/src/scriptrag/search/vector.py
+++ b/src/scriptrag/search/vector.py
@@ -20,7 +20,7 @@ logger = get_logger(__name__)
 class VectorSearchEngine:
     """Handle vector/semantic search operations."""
 
-    def __init__(self, settings: ScriptRAGSettings | None = None):
+    def __init__(self, settings: ScriptRAGSettings | None = None) -> None:
         """Initialize vector search engine.
 
         Args:


### PR DESCRIPTION
## Summary
- Improves type annotation coverage by adding explicit `-> None` return types to `__init__` methods across multiple classes
- Enhances code clarity and consistency in type hints

## Changes

### Type Annotation Updates
- Added `-> None` return type annotations to constructors in 17 files including:
  - `context_query.py`
  - `base.py`
  - `analyze.py`
  - `bible_index.py`
  - `database_operations.py`
  - `index.py`
  - `query.py`
  - `scene_management.py`
  - `search.py`
  - `file_source.py`
  - `model_discovery.py` (updated method `_parse_anthropic_models` with detailed type hints)
  - `engine.py` (query and search engines)
  - `formatter.py` (query and search formatters)
  - `loader.py`
  - `vector.py`

## Test plan
- No functional changes; existing tests should pass without modification
- Type checking tools (e.g., mypy) should reflect improved type coverage without errors

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1e9645ee-d6c7-4d0f-80c7-8b36ca7922b5