### PR TITLE
Remove skipped tests for unmockable sqlite3.Cursor.lastrowid

### DIFF
--- a/tests/unit/test_database_operations.py
+++ b/tests/unit/test_database_operations.py
@@ -596,21 +596,3 @@ class TestDatabaseOperations:
                 (scene_id,),
             )
             assert cursor.fetchone()["count"] == 2
-
-    @pytest.mark.skip(reason="Cannot mock read-only sqlite3.Cursor.lastrowid property")
-    def test_upsert_script_insert_lastrowid_none(self, initialized_db, sample_script):
-        """Test upsert_script handles None lastrowid on insert."""
-        # This test cannot be easily implemented because sqlite3.Cursor.lastrowid
-        # is a read-only property that cannot be mocked in the normal way.
-        # The error condition it tests (lastrowid being None after INSERT)
-        # is extremely rare in practice and would indicate a serious database issue.
-        pass
-
-    @pytest.mark.skip(reason="Cannot mock read-only sqlite3.Cursor.lastrowid property")
-    def test_upsert_scene_insert_lastrowid_none(self, initialized_db, sample_script):
-        """Test upsert_scene handles None lastrowid on insert."""
-        # This test cannot be easily implemented because sqlite3.Cursor.lastrowid
-        # is a read-only property that cannot be mocked in the normal way.
-        # The error condition it tests (lastrowid being None after INSERT)
-        # is extremely rare in practice and would indicate a serious database issue.
-        pass


### PR DESCRIPTION
## Summary
- Removed two skipped tests in `test_database_operations.py` that attempted to mock the read-only `sqlite3.Cursor.lastrowid` property
- These tests were marked as skipped because mocking `lastrowid` is not feasible and the error condition is extremely rare

## Changes

### Tests
- Deleted `test_upsert_script_insert_lastrowid_none` and `test_upsert_scene_insert_lastrowid_none` which were skipped due to inability to mock `lastrowid`
- Cleaned up test file by removing unused placeholder tests

## Test plan
- Existing tests remain unchanged and continue to verify database operations
- No new tests added since the removed tests were non-functional placeholders

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4ee2db1f-ff77-4655-822e-7ec2395b498a