### PR TITLE
fix(llm,query): stabilize provider fallback, context queries, and embed model classification

### DIFF
--- a/src/scriptrag/agents/context_query.py
+++ b/src/scriptrag/agents/context_query.py
@@ -91,6 +91,18 @@ class ContextParameters:
             # Generate script_id from file path or metadata
             if hasattr(script, "file_path"):
                 file_str = str(script.file_path)
+            else:
+                # Fallback to source file stored in script metadata
+                file_str = None
+                try:
+                    meta = getattr(script, "metadata", {}) or {}
+                    src = meta.get("source_file")
+                    if src:
+                        file_str = str(src)
+                except Exception:  # pragma: no cover - defensive fallback
+                    file_str = None
+
+            if file_str:
                 params.script_id = hashlib.sha256(file_str.encode()).hexdigest()[
                     :HASH_ID_LENGTH
                 ]

--- a/src/scriptrag/llm/fallback.py
+++ b/src/scriptrag/llm/fallback.py
@@ -76,6 +76,9 @@ class FallbackHandler:
         attempted_providers: list[str] = []
         fallback_chain: list[str] = []
         debug_info: dict[str, Any] = {}
+        # Preserve the original request model so provider attempts don't
+        # accidentally reuse a model selected by a previous provider.
+        original_model = request.model
 
         logger.info(
             "Starting LLM completion with fallback strategy",
@@ -94,9 +97,12 @@ class FallbackHandler:
 
         # Try preferred provider first
         if self.preferred_provider:
+            # Use a fresh request copy for each provider attempt
+            req_copy = request.model_copy()
+            req_copy.model = original_model
             result = await self._try_provider(
                 self.preferred_provider,
-                request,
+                req_copy,
                 try_provider_func,
                 provider_errors,
                 attempted_providers,
@@ -115,9 +121,12 @@ class FallbackHandler:
                 )
                 continue
 
+            # Use a fresh request copy for each provider attempt
+            req_copy = request.model_copy()
+            req_copy.model = original_model
             result = await self._try_provider(
                 provider_type,
-                request,
+                req_copy,
                 try_provider_func,
                 provider_errors,
                 attempted_providers,
@@ -172,6 +181,7 @@ class FallbackHandler:
         attempted_providers: list[str] = []
         fallback_chain: list[str] = []
         debug_info: dict[str, Any] = {}
+        original_model = request.model
 
         # Build the complete fallback chain
         if self.preferred_provider:
@@ -182,9 +192,11 @@ class FallbackHandler:
 
         # Try preferred provider first
         if self.preferred_provider:
+            req_copy = request.model_copy()
+            req_copy.model = original_model
             result = await self._try_provider(
                 self.preferred_provider,
-                request,
+                req_copy,
                 try_provider_func,
                 provider_errors,
                 attempted_providers,
@@ -200,9 +212,11 @@ class FallbackHandler:
             if provider_type == self.preferred_provider:
                 continue
 
+            req_copy = request.model_copy()
+            req_copy.model = original_model
             result = await self._try_provider(
                 provider_type,
-                request,
+                req_copy,
                 try_provider_func,
                 provider_errors,
                 attempted_providers,

--- a/src/scriptrag/query/engine.py
+++ b/src/scriptrag/query/engine.py
@@ -78,7 +78,12 @@ class QueryEngine:
             validated_params["offset"] = 0
 
         # Prepare SQL
-        sql = spec.sql
+        # Normalize SQL by trimming whitespace and removing a trailing semicolon.
+        # This avoids syntax errors when wrapping the statement in a subquery
+        # for LIMIT/OFFSET handling (SQLite disallows a semicolon inside).
+        sql = spec.sql.strip()
+        if sql.endswith(";"):
+            sql = sql[:-1].rstrip()
 
         # Wrap SQL if limit/offset not in original query but provided in params
         if not has_limit and "limit" in validated_params:


### PR DESCRIPTION
This PR fixes several stability issues uncovered during integration tests and provider fallback flows.

Summary of changes
- Strip trailing semicolons to avoid SQLite subquery wrap errors in context queries.
- Derive script_id from script metadata when file_path is unavailable (context params binding).
- Clone requests per provider attempt and reset  to the original to prevent cross-provider model leakage in fallback.
- Correctly classify embedding-only models via 'embed', 'embedding', and 'text-embedding' and broaden recognized chat families; add missing regex import.

Validation
- Targeted unit tests for model discovery: pass.
- Isolated integration test for context queries: pass.
- Full LLM-dependent suites still rely on external availability and may be skipped in CI when rate-limited.

Refs: #1

"We’re gonna need a bigger boat." - Martin Brody, Jaws (1975)
