### PR TITLE
perf(llm): optimize cache dir permission checks

### DIFF
--- a/src/scriptrag/llm/model_cache.py
+++ b/src/scriptrag/llm/model_cache.py
@@ -49,10 +49,11 @@ class ModelDiscoveryCache:
     def _ensure_cache_dir(self) -> None:
         """Ensure cache directory exists with restrictive permissions."""
         try:
-            # Create directory with restrictive permissions
-            self.CACHE_DIR.mkdir(parents=True, exist_ok=True)
-            # Set restrictive permissions (owner read/write/execute only)
-            self.CACHE_DIR.chmod(0o700)
+            # Only set permissions when creating the directory the first time
+            if not self.CACHE_DIR.exists():
+                self.CACHE_DIR.mkdir(parents=True, exist_ok=True)
+                # Set restrictive permissions (owner read/write/execute only)
+                self.CACHE_DIR.chmod(0o700)
         except OSError as e:
             logger.error(f"Failed to create cache directory: {e}")
             raise

--- a/src/scriptrag/llm/model_cache.py
+++ b/src/scriptrag/llm/model_cache.py
@@ -49,9 +49,11 @@ class ModelDiscoveryCache:
     def _ensure_cache_dir(self) -> None:
         """Ensure cache directory exists with restrictive permissions."""
         try:
-            # Only set permissions when creating the directory the first time
-            if not self.CACHE_DIR.exists():
-                self.CACHE_DIR.mkdir(parents=True, exist_ok=True)
+            # Always attempt to create the directory (idempotent with exist_ok),
+            # but only set permissions when it's created the first time.
+            existed = self.CACHE_DIR.exists()
+            self.CACHE_DIR.mkdir(parents=True, exist_ok=True)
+            if not existed:
                 # Set restrictive permissions (owner read/write/execute only)
                 self.CACHE_DIR.chmod(0o700)
         except OSError as e:


### PR DESCRIPTION
perf(llm): optimize cache dir permission checks

Summary
- Optimize `_ensure_cache_dir` to set `0o700` only when creating the cache dir for the first time.
- Avoids redundant `chmod` on every write, reducing unnecessary filesystem ops.

Context
- Implements the minor optimization suggested in PR #299 review.
- Scope is limited to `src/scriptrag/llm/model_cache.py`.

Testing
- Focused cache tests pass locally:
  - `tests/llm/test_model_cache_coverage.py`
  - `tests/unit/test_llm_model_discovery.py::TestModelDiscoveryCache`
- Broader suite has unrelated failures pre-existing on `main`; CI canary reflects that.

Quote
"If you build it, he will come." - The Voice, Field of Dreams (1989)

Refs: #299
