### PR TITLE
Fix type annotation for CacheData using TypedDict

### DIFF
--- a/src/scriptrag/llm/model_cache.py
+++ b/src/scriptrag/llm/model_cache.py
@@ -7,7 +7,7 @@ import os
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, TypedDict
 
 from pydantic_core import ValidationError
 
@@ -17,7 +17,7 @@ from scriptrag.llm.models import Model
 logger = get_logger(__name__)
 
 
-class CacheData:
+class CacheData(TypedDict):
     """Type for cache data structure."""
 
     timestamp: float


### PR DESCRIPTION
## Summary
- Corrects the type annotation of `CacheData` in `model_cache.py` by using `TypedDict` instead of a regular class
- Improves type safety and clarity for the cache data structure

## Changes

### Type Annotation
- Changed `CacheData` from a plain class to a `TypedDict` to properly represent the expected dictionary structure
- Added import for `TypedDict` from `typing` module

## Test plan
- Ensure existing functionality related to cache data works without type errors
- Verify that type checkers recognize `CacheData` as a dictionary with specified keys and types

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/8697cc9c-a210-465c-b098-9de49ddaf692