### PR TITLE
Refactor async event loop handling in file watcher to use asyncio.run

### DIFF
--- a/src/scriptrag/cli/utils/file_watcher.py
+++ b/src/scriptrag/cli/utils/file_watcher.py
@@ -208,13 +208,9 @@ class FountainFileHandler(FileSystemEventHandler):
             if self.callback:
                 self.callback("processing", path)
 
-            # Run the pull workflow in a new event loop
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            try:
-                loop.run_until_complete(self._pull_single_file(path))
-            finally:
-                loop.close()
+            # Run the pull workflow using asyncio.run() for proper event loop management
+            # This ensures thread safety and proper cleanup
+            asyncio.run(self._pull_single_file(path))
 
             if self.callback:
                 self.callback("completed", path)


### PR DESCRIPTION
## Summary
- Refactored the file watcher to use `asyncio.run()` instead of manually creating and managing event loops
- Improved thread safety and ensured proper cleanup of async tasks
- Updated unit tests to mock `asyncio.run()` instead of event loop methods

## Changes

### Core Functionality
- Replaced manual event loop creation and management in `FountainFileHandler._process_file_sync` with `asyncio.run()` for running async pull workflow
- This change simplifies async code and avoids potential issues with event loop conflicts

### Tests
- Modified tests to patch `asyncio.run` instead of `asyncio.new_event_loop` and related loop methods
- Adjusted mocks and assertions accordingly
- Removed redundant loop close assertions since `asyncio.run` handles cleanup

## Test plan
- [x] Run existing unit tests to verify async file processing still works correctly
- [x] Confirm error handling in async processing remains intact
- [x] Validate no regressions in file watcher behavior during file modifications

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6d83bfa3-4de9-494a-88c2-ba43060326e2