### PR TITLE
Enforce string type for log_level and log_format with enhanced tests

### DIFF
--- a/src/scriptrag/config/settings.py
+++ b/src/scriptrag/config/settings.py
@@ -224,7 +224,8 @@ class ScriptRAGSettings(BaseSettings):
         """Normalize log level to uppercase for case-insensitive handling."""
         if isinstance(v, str):
             return v.upper()
-        return str(v)
+        # Only accept string values, reject other types
+        raise ValueError(f"log_level must be a string, got {type(v).__name__}")
 
     @field_validator("log_format", mode="before")
     @classmethod
@@ -232,7 +233,8 @@ class ScriptRAGSettings(BaseSettings):
         """Normalize log format to lowercase for case-insensitive handling."""
         if isinstance(v, str):
             return v.lower()
-        return str(v)
+        # Only accept string values, reject other types
+        raise ValueError(f"log_format must be a string, got {type(v).__name__}")
 
     @classmethod
     def from_env(cls) -> "ScriptRAGSettings":

--- a/tests/unit/test_settings_case_insensitive_logging.py
+++ b/tests/unit/test_settings_case_insensitive_logging.py
@@ -293,29 +293,49 @@ database_path = "/tmp/test.db"
         assert root_logger.level == logging.DEBUG
 
     def test_log_level_non_string_input(self):
-        """Test that non-string log level inputs are converted to strings."""
+        """Test that non-string log level inputs are rejected."""
         # Test integer input
-        with pytest.raises(ValueError, match="pattern"):
+        with pytest.raises(ValueError, match="log_level must be a string"):
             ScriptRAGSettings(log_level=123)
 
         # Test None input
-        with pytest.raises(ValueError, match="pattern"):
+        with pytest.raises(ValueError, match="log_level must be a string"):
             ScriptRAGSettings(log_level=None)
 
         # Test boolean input
-        with pytest.raises(ValueError, match="pattern"):
+        with pytest.raises(ValueError, match="log_level must be a string"):
             ScriptRAGSettings(log_level=True)
 
     def test_log_format_non_string_input(self):
-        """Test that non-string log format inputs are converted to strings."""
+        """Test that non-string log format inputs are rejected."""
         # Test integer input
-        with pytest.raises(ValueError, match="pattern"):
+        with pytest.raises(ValueError, match="log_format must be a string"):
             ScriptRAGSettings(log_format=123)
 
         # Test None input
-        with pytest.raises(ValueError, match="pattern"):
+        with pytest.raises(ValueError, match="log_format must be a string"):
             ScriptRAGSettings(log_format=None)
 
         # Test boolean input
-        with pytest.raises(ValueError, match="pattern"):
+        with pytest.raises(ValueError, match="log_format must be a string"):
             ScriptRAGSettings(log_format=False)
+
+    def test_log_level_list_input(self):
+        """Test that list log level inputs are rejected."""
+        with pytest.raises(ValueError, match="log_level must be a string"):
+            ScriptRAGSettings(log_level=["DEBUG"])
+
+    def test_log_level_dict_input(self):
+        """Test that dict log level inputs are rejected."""
+        with pytest.raises(ValueError, match="log_level must be a string"):
+            ScriptRAGSettings(log_level={"level": "DEBUG"})
+
+    def test_log_format_list_input(self):
+        """Test that list log format inputs are rejected."""
+        with pytest.raises(ValueError, match="log_format must be a string"):
+            ScriptRAGSettings(log_format=["console"])
+
+    def test_log_format_dict_input(self):
+        """Test that dict log format inputs are rejected."""
+        with pytest.raises(ValueError, match="log_format must be a string"):
+            ScriptRAGSettings(log_format={"format": "json"})


### PR DESCRIPTION
## Summary
- Updated `ScriptRAGSettings` to strictly enforce that `log_level` and `log_format` must be strings.
- Replaced previous behavior of converting non-string inputs to strings with raising `ValueError` for invalid types.
- Expanded unit tests to cover rejection of various non-string types including lists and dictionaries.

## Changes

### Core Functionality
- Modified `log_level` and `log_format` validators in `settings.py` to raise errors if input is not a string.

### Tests
- Updated existing tests to expect `ValueError` when non-string inputs are provided.
- Added new tests to verify rejection of list and dictionary inputs for both `log_level` and `log_format`.

## Test plan
- Run unit tests to ensure all cases of invalid input types raise appropriate errors.
- Confirm that valid string inputs continue to be accepted and normalized correctly.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a0bee091-02da-42c5-9b1a-3de0101481be