### PR TITLE
Fix null count query results in search engine and add tests

### DIFF
--- a/src/scriptrag/search/engine.py
+++ b/src/scriptrag/search/engine.py
@@ -196,7 +196,8 @@ class SearchEngine:
                 # Build and execute count query for pagination
                 count_sql, count_params = self.query_builder.build_count_query(query)
                 count_cursor = conn.execute(count_sql, count_params)
-                total_count = count_cursor.fetchone()["total"]
+                count_result = count_cursor.fetchone()
+                total_count = count_result["total"] if count_result else 0
 
                 # Convert rows to SearchResult objects
                 for idx, row in enumerate(rows):
@@ -377,7 +378,8 @@ class SearchEngine:
             )
             count_sql = "SELECT COUNT(*) as total FROM " + count_sql
             count_cursor = conn.execute(count_sql, params)
-            bible_total_count = count_cursor.fetchone()["total"]
+            count_result = count_cursor.fetchone()
+            bible_total_count = count_result["total"] if count_result else 0
 
             # Convert rows to BibleSearchResult objects
             for row in rows:


### PR DESCRIPTION
## Summary
- Fixes handling of null results from count queries in the search engine to prevent exceptions
- Ensures total count defaults to 0 when count query returns no rows
- Adds comprehensive unit tests to cover scenarios where count queries return null

## Changes

### Core Fixes
- Updated `SearchEngine` to safely handle `fetchone()` returning `None` for count queries
- Applied fix in both general search and Bible search count queries

### Tests
- Added `test_search_null_count_result` to verify search handles null count results gracefully
- Added `test_bible_search_null_count_result` to verify Bible search handles null count results gracefully
- Created minimal in-memory database schemas for testing these edge cases
- Mocked query builder and search methods to simulate null count query results

## Test plan
- [x] Run new unit tests to confirm no exceptions occur when count queries return null
- [x] Verify total count is correctly set to 0 in these cases
- [x] Confirm existing search functionality remains unaffected

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b8f01891-3fef-4511-926e-c8064b76fca8