### PR TITLE
Fix search count query handling and add robust unit tests

### DIFF
--- a/src/scriptrag/search/engine.py
+++ b/src/scriptrag/search/engine.py
@@ -197,7 +197,15 @@ class SearchEngine:
                 count_sql, count_params = self.query_builder.build_count_query(query)
                 count_cursor = conn.execute(count_sql, count_params)
                 count_result = count_cursor.fetchone()
-                total_count = count_result["total"] if count_result else 0
+                # Handle None result or missing 'total' key gracefully
+                if count_result:
+                    try:
+                        total_count = count_result["total"] or 0
+                    except (KeyError, TypeError, IndexError):
+                        # Handle various cases where 'total' key is missing
+                        total_count = 0
+                else:
+                    total_count = 0
 
                 # Convert rows to SearchResult objects
                 for idx, row in enumerate(rows):


### PR DESCRIPTION
## Summary
- Fixes handling of count query results in `SearchEngine` to gracefully manage `None` or malformed results
- Adds extensive unit tests to cover scenarios where count query returns `None` or has malformed data

## Changes

### Core Fix
- Updated `SearchEngine.search` method to safely extract `total` count from count query result
- Added try-except block to handle missing or malformed `total` key in count query result

### Tests
- Added `test_search_handles_null_count_query_result` to verify search handles `None` count query result without crashing
- Added `test_search_handles_malformed_count_query_result` to verify search handles malformed count query result (wrong column name) gracefully
- Both tests create minimal in-memory SQLite databases and mock count queries to simulate edge cases

## Test plan
- [x] Run unit tests to confirm no exceptions are raised when count query returns `None` or malformed data
- [x] Verify search returns empty results and zero total count in these edge cases
- [x] Confirm existing search functionality remains unaffected

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/304ca2f0-4a0c-4873-9488-713e8885785b