### PR TITLE
Fix invalid memory cache entry handling in ModelDiscoveryCache

### DIFF
--- a/src/scriptrag/llm/model_cache.py
+++ b/src/scriptrag/llm/model_cache.py
@@ -101,7 +101,7 @@ class ModelDiscoveryCache:
                         f"In-memory cache expired for {self.provider_name}",
                         age=int(time.time() - timestamp),
                     )
-            else:
+            elif isinstance(entry, tuple) and len(entry) == 2:
                 # Backward-compat: older 2-tuple shape (timestamp, models)
                 timestamp = cast(float, entry[0])
                 models = cast(list[Model], entry[1])
@@ -115,6 +115,14 @@ class ModelDiscoveryCache:
                 # Clear expired in-memory cache
                 del self._memory_cache[self.provider_name]
                 logger.debug(f"In-memory cache expired for {self.provider_name}")
+            else:
+                # Invalid cache entry - clear it
+                logger.warning(
+                    f"Invalid cache entry for {self.provider_name}, clearing",
+                    entry_type=type(entry).__name__,
+                    entry_len=len(entry) if isinstance(entry, tuple) else "N/A",
+                )
+                del self._memory_cache[self.provider_name]
 
         # Fall back to file cache
         if not self.cache_file.exists():


### PR DESCRIPTION
## Summary
- Fixes handling of invalid entries in the in-memory cache of `ModelDiscoveryCache`.
- Adds logging and clearing of invalid cache entries to prevent stale or corrupted data.
- Improves robustness of cache retrieval by validating cache entry structure.

## Changes

### Core Functionality
- Updated `ModelDiscoveryCache.get` method to detect and clear invalid cache entries that are not tuples of length 2 or 3.
- Added warning logs with details about the invalid cache entry type and length.

### Tests
- Added comprehensive tests in `test_model_cache_coverage.py` covering various invalid cache entry scenarios:
  - Empty tuple
  - Single-element tuple
  - Non-tuple entry (e.g., string)
  - Wrong-sized tuple (not 2 or 3 elements)
- Tests verify that invalid entries return `None`, log appropriate warnings, and clear the invalid cache entry.

## Test plan
- [x] Run new and existing tests to ensure invalid cache entries are handled gracefully.
- [x] Verify warning logs are emitted for invalid cache entries.
- [x] Confirm that invalid entries are removed from the in-memory cache after detection.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1125f85f-0f95-4d2d-84d0-e267cb18909a