### PR TITLE
Normalize LLM model sentinel values in settings

### DIFF
--- a/src/scriptrag/config/settings.py
+++ b/src/scriptrag/config/settings.py
@@ -241,6 +241,23 @@ class ScriptRAGSettings(BaseSettings):
         """Create settings from environment variables."""
         return cls()
 
+    @field_validator("llm_model", "llm_embedding_model", mode="before")
+    @classmethod
+    def normalize_llm_models(cls, v: Any) -> Any:
+        """Normalize sentinel values for LLM model fields.
+
+        Treat common placeholders like "default", "auto", empty strings,
+        and "none" (any casing/whitespace) as unset (None) so that the
+        application can auto-select appropriate models at runtime.
+        """
+        if v is None:
+            return None
+        if isinstance(v, str):
+            normalized = v.strip().lower()
+            if normalized in {"", "default", "auto", "none"}:
+                return None
+        return v
+
     @classmethod
     def from_file(cls, config_path: Path | str) -> "ScriptRAGSettings":
         """Load settings from a configuration file.

--- a/tests/unit/test_settings_normalization.py
+++ b/tests/unit/test_settings_normalization.py
@@ -1,0 +1,24 @@
+import pytest
+
+from scriptrag.config.settings import ScriptRAGSettings
+
+
+def test_llm_embedding_model_default_string_is_normalized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Ensure environment is set to the sentinel value
+    monkeypatch.setenv("SCRIPTRAG_LLM_EMBEDDING_MODEL", "default")
+    settings = ScriptRAGSettings.from_env()
+    assert settings.llm_embedding_model is None
+
+
+def test_llm_model_auto_and_empty_normalized(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 'auto' should become None
+    monkeypatch.setenv("SCRIPTRAG_LLM_MODEL", "auto")
+    settings = ScriptRAGSettings.from_env()
+    assert settings.llm_model is None
+
+    # Empty string should become None
+    monkeypatch.setenv("SCRIPTRAG_LLM_MODEL", "   ")
+    settings = ScriptRAGSettings.from_env()
+    assert settings.llm_model is None


### PR DESCRIPTION
## Summary
- Adds normalization for sentinel values in LLM model configuration fields
- Treats common placeholders like "default", "auto", empty strings, and "none" (case-insensitive) as unset (None)
- Enables automatic model selection by the application when these placeholders are used

## Changes

### Configuration Settings
- Introduced `normalize_llm_models` validator for `llm_model` and `llm_embedding_model` fields in `ScriptRAGSettings`
- Validator cleans and normalizes input values before assignment

### Tests
- Added unit tests to verify normalization behavior for environment variable inputs:
  - "default" for embedding model
  - "auto" and empty strings for LLM model

## Test plan
- [x] Confirm environment variables with sentinel values are normalized to None
- [x] Run unit tests to ensure normalization logic correctness
- [x] Validate that application can auto-select models when placeholders are used

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f9ced704-f186-4057-a426-25e5d54ab9ad