### PR TITLE
fix: add validation for corrupted embedding data in decode_embedding_from_db

### DIFF
--- a/src/scriptrag/api/semantic_search.py
+++ b/src/scriptrag/api/semantic_search.py
@@ -175,9 +175,19 @@ class SemanticSearchService:
                 return []
 
             # Decode source embedding
-            source_embedding: list[float] = (
-                self.embedding_service.decode_embedding_from_db(source_embedding_bytes)
-            )
+            try:
+                source_embedding: list[float] = (
+                    self.embedding_service.decode_embedding_from_db(
+                        source_embedding_bytes
+                    )
+                )
+            except ValueError as e:
+                logger.warning(
+                    "Failed to decode source scene embedding",
+                    scene_id=scene_id,
+                    error=str(e),
+                )
+                return []
 
             # Get scenes with embeddings
             candidates: list[dict[str, Any]] = self.db_ops.search_similar_scenes(

--- a/tests/unit/test_embedding_decode_validation.py
+++ b/tests/unit/test_embedding_decode_validation.py
@@ -1,0 +1,164 @@
+"""Test embedding decoding validation in EmbeddingService."""
+
+import struct
+from pathlib import Path
+
+import pytest
+
+from scriptrag.api.embedding_service import EmbeddingService
+from scriptrag.config import ScriptRAGSettings
+
+
+@pytest.fixture
+def embedding_service(tmp_path: Path) -> EmbeddingService:
+    """Create an embedding service instance for testing."""
+    settings = ScriptRAGSettings()
+    return EmbeddingService(settings, cache_dir=tmp_path / "cache")
+
+
+class TestEmbeddingDecodeValidation:
+    """Test decode_embedding_from_db validation."""
+
+    def test_decode_valid_embedding(self, embedding_service: EmbeddingService) -> None:
+        """Test decoding a valid embedding."""
+        # Create a valid embedding
+        embedding = [0.1, 0.2, 0.3, 0.4, 0.5]
+        encoded = embedding_service.encode_embedding_for_db(embedding)
+
+        # Decode should work
+        decoded = embedding_service.decode_embedding_from_db(encoded)
+        assert len(decoded) == len(embedding)
+        assert all(
+            abs(a - b) < 0.0001 for a, b in zip(decoded, embedding, strict=False)
+        )
+
+    def test_decode_empty_data(self, embedding_service: EmbeddingService) -> None:
+        """Test decoding empty data raises ValueError."""
+        with pytest.raises(ValueError, match="Embedding data too short"):
+            embedding_service.decode_embedding_from_db(b"")
+
+    def test_decode_short_data(self, embedding_service: EmbeddingService) -> None:
+        """Test decoding data shorter than 4 bytes raises ValueError."""
+        with pytest.raises(ValueError, match="Embedding data too short"):
+            embedding_service.decode_embedding_from_db(b"abc")
+
+    def test_decode_zero_dimension(self, embedding_service: EmbeddingService) -> None:
+        """Test decoding with zero dimension raises ValueError."""
+        # Pack dimension=0
+        data = struct.pack("<I", 0)
+        with pytest.raises(ValueError, match="Embedding dimension cannot be zero"):
+            embedding_service.decode_embedding_from_db(data)
+
+    def test_decode_excessive_dimension(
+        self, embedding_service: EmbeddingService
+    ) -> None:
+        """Test decoding with excessive dimension raises ValueError."""
+        # Pack dimension=20000 (exceeds max_dimension=10000)
+        data = struct.pack("<I", 20000)
+        with pytest.raises(ValueError, match="exceeds maximum allowed"):
+            embedding_service.decode_embedding_from_db(data)
+
+    def test_decode_truncated_data(self, embedding_service: EmbeddingService) -> None:
+        """Test decoding truncated data raises ValueError."""
+        # Create data that claims to have 5 floats but only has 3
+        dimension = 5
+        truncated_floats = [0.1, 0.2, 0.3]
+        data = struct.pack("<I", dimension) + struct.pack(
+            f"<{len(truncated_floats)}f", *truncated_floats
+        )
+
+        with pytest.raises(ValueError, match="Embedding data truncated"):
+            embedding_service.decode_embedding_from_db(data)
+
+    def test_decode_corrupted_float_data(
+        self, embedding_service: EmbeddingService
+    ) -> None:
+        """Test decoding with corrupted float data raises ValueError."""
+        # Create data with valid dimension but not enough bytes for floats
+        dimension = 2
+        data = struct.pack("<I", dimension) + b"invalid"  # Only 7 extra bytes, need 8
+
+        # This will trigger the truncated data check first
+        with pytest.raises(ValueError, match="Embedding data truncated"):
+            embedding_service.decode_embedding_from_db(data)
+
+    def test_decode_large_valid_embedding(
+        self, embedding_service: EmbeddingService
+    ) -> None:
+        """Test decoding a large but valid embedding."""
+        # Test with a typical large embedding size (1536 dimensions)
+        embedding = [0.1] * 1536
+        encoded = embedding_service.encode_embedding_for_db(embedding)
+
+        decoded = embedding_service.decode_embedding_from_db(encoded)
+        assert len(decoded) == 1536
+        assert all(abs(v - 0.1) < 0.0001 for v in decoded)
+
+    def test_decode_negative_dimension_as_unsigned(
+        self, embedding_service: EmbeddingService
+    ) -> None:
+        """Test that negative dimension (when interpreted as unsigned) is caught."""
+        # -1 as signed int becomes 4294967295 as unsigned int
+        data = struct.pack("<i", -1)  # Pack as signed, will be read as unsigned
+        with pytest.raises(ValueError, match="exceeds maximum allowed"):
+            embedding_service.decode_embedding_from_db(data)
+
+    def test_decode_exact_boundary_dimension(
+        self, embedding_service: EmbeddingService
+    ) -> None:
+        """Test decoding at the exact maximum dimension boundary."""
+        # Test at exactly max_dimension (10000)
+        dimension = 10000
+        # Create minimal valid data (dimension + one float to avoid truncation error)
+        data = (
+            struct.pack("<I", dimension)
+            + struct.pack("<f", 0.1)
+            + b"\x00" * (dimension * 4 - 4)
+        )
+
+        # Should work as it's exactly at the limit
+        decoded = embedding_service.decode_embedding_from_db(data)
+        assert len(decoded) == dimension
+
+    def test_decode_just_over_boundary(
+        self, embedding_service: EmbeddingService
+    ) -> None:
+        """Test decoding just over the maximum dimension boundary."""
+        # Test at max_dimension + 1 (10001)
+        dimension = 10001
+        data = struct.pack("<I", dimension)
+
+        with pytest.raises(ValueError, match="exceeds maximum allowed"):
+            embedding_service.decode_embedding_from_db(data)
+
+    def test_decode_malformed_struct_data(
+        self, embedding_service: EmbeddingService
+    ) -> None:
+        """Test decoding with data that passes length check but fails struct unpack."""
+        # Create data with correct length but NaN/Inf values that might cause issues
+        dimension = 2
+        # Pack dimension + exactly 8 bytes that form invalid floats
+        data = struct.pack("<I", dimension) + struct.pack(
+            "<ff", float("nan"), float("inf")
+        )
+
+        # Should successfully decode even with NaN/Inf (they're valid float values)
+        decoded = embedding_service.decode_embedding_from_db(data)
+        assert len(decoded) == 2
+        # Note: NaN != NaN in Python, so we can't use equality check
+
+    def test_round_trip_various_sizes(
+        self, embedding_service: EmbeddingService
+    ) -> None:
+        """Test encoding and decoding round-trip for various embedding sizes."""
+        test_sizes = [1, 128, 256, 512, 768, 1024, 1536, 2048, 3072, 4096]
+
+        for size in test_sizes:
+            embedding = [float(i) / size for i in range(size)]
+            encoded = embedding_service.encode_embedding_for_db(embedding)
+            decoded = embedding_service.decode_embedding_from_db(encoded)
+
+            assert len(decoded) == size
+            assert all(
+                abs(a - b) < 0.0001 for a, b in zip(decoded, embedding, strict=False)
+            )

--- a/tests/unit/test_semantic_result_error_handling.py
+++ b/tests/unit/test_semantic_result_error_handling.py
@@ -1,0 +1,236 @@
+"""Test error handling in semantic result processing."""
+
+from typing import Any
+from unittest.mock import Mock
+
+from scriptrag.api.semantic_result_processing import (
+    build_bible_results,
+    build_scene_results,
+)
+
+
+class TestSemanticResultErrorHandling:
+    """Test error handling in semantic result processing functions."""
+
+    def test_build_scene_results_skips_corrupted_embeddings(self) -> None:
+        """Test that scenes with corrupted embeddings are skipped."""
+        # Mock embedding service
+        mock_embedding_service = Mock()
+
+        # First call raises ValueError (corrupted), second succeeds
+        mock_embedding_service.decode_embedding_from_db.side_effect = [
+            ValueError("Corrupted embedding"),
+            [0.1, 0.2, 0.3],  # Valid embedding for second scene
+        ]
+        mock_embedding_service.cosine_similarity.return_value = 0.8
+
+        # Mock builder
+        def builder(**kwargs: Any) -> dict[str, Any]:
+            return {"similarity_score": kwargs["similarity_score"], **kwargs}
+
+        # Test data with two scenes
+        candidates = [
+            {
+                "id": 1,
+                "script_id": 100,
+                "heading": "Scene 1",
+                "location": "INT. HOUSE",
+                "content": "Content 1",
+                "_embedding": b"corrupted_data",
+                "metadata": {},
+            },
+            {
+                "id": 2,
+                "script_id": 100,
+                "heading": "Scene 2",
+                "location": "EXT. STREET",
+                "content": "Content 2",
+                "_embedding": b"valid_data",
+                "metadata": {},
+            },
+        ]
+
+        query_embedding = [0.4, 0.5, 0.6]
+
+        # Build results
+        results = build_scene_results(
+            candidates,
+            query_embedding=query_embedding,
+            embedding_service=mock_embedding_service,
+            threshold=0.5,
+            builder=builder,
+        )
+
+        # Should only have one result (the valid one)
+        assert len(results) == 1
+        assert results[0]["scene_id"] == 2
+        assert results[0]["heading"] == "Scene 2"
+
+    def test_build_scene_results_handles_missing_embedding_key(self) -> None:
+        """Test that scenes missing embedding key are skipped."""
+        mock_embedding_service = Mock()
+        mock_embedding_service.decode_embedding_from_db.side_effect = KeyError(
+            "_embedding"
+        )
+
+        def builder(**kwargs: Any) -> dict[str, Any]:
+            return {"similarity_score": kwargs["similarity_score"], **kwargs}
+
+        # Scene missing _embedding key will be handled
+        candidates = [
+            {
+                "id": 1,
+                "script_id": 100,
+                "heading": "Scene 1",
+                "content": "Content 1",
+                "_embedding": b"data",  # Will raise KeyError in mock
+            }
+        ]
+
+        results = build_scene_results(
+            candidates,
+            query_embedding=[0.1, 0.2],
+            embedding_service=mock_embedding_service,
+            threshold=0.5,
+            builder=builder,
+        )
+
+        # Should have no results
+        assert len(results) == 0
+
+    def test_build_bible_results_skips_corrupted_embeddings(self) -> None:
+        """Test that bible chunks with corrupted embeddings are skipped."""
+        mock_embedding_service = Mock()
+
+        # First call raises ValueError, second and third succeed
+        mock_embedding_service.decode_embedding_from_db.side_effect = [
+            ValueError("Corrupted embedding"),
+            [0.1, 0.2, 0.3],
+            [0.4, 0.5, 0.6],
+        ]
+        mock_embedding_service.cosine_similarity.side_effect = [0.9, 0.6]
+
+        def builder(**kwargs: Any) -> dict[str, Any]:
+            return {"similarity_score": kwargs["similarity_score"], **kwargs}
+
+        chunks = [
+            {
+                "id": 1,
+                "bible_id": 10,
+                "script_id": 100,
+                "bible_title": "Bible 1",
+                "heading": "Chapter 1",
+                "content": "Content 1",
+                "embedding": b"corrupted",
+                "level": 1,
+                "metadata": {},
+            },
+            {
+                "id": 2,
+                "bible_id": 10,
+                "script_id": 100,
+                "bible_title": "Bible 1",
+                "heading": "Chapter 2",
+                "content": "Content 2",
+                "embedding": b"valid1",
+                "level": 1,
+                "metadata": {},
+            },
+            {
+                "id": 3,
+                "bible_id": 10,
+                "script_id": 100,
+                "bible_title": "Bible 1",
+                "heading": "Chapter 3",
+                "content": "Content 3",
+                "embedding": b"valid2",
+                "level": 1,
+                "metadata": {},
+            },
+        ]
+
+        results = build_bible_results(
+            chunks,
+            query_embedding=[0.7, 0.8, 0.9],
+            embedding_service=mock_embedding_service,
+            threshold=0.5,
+            builder=builder,
+        )
+
+        # Should have two results (the valid ones)
+        assert len(results) == 2
+        # Results should be sorted by similarity score (descending)
+        assert results[0]["chunk_id"] == 2  # similarity 0.9
+        assert results[1]["chunk_id"] == 3  # similarity 0.6
+
+    def test_build_scene_results_with_skip_id(self) -> None:
+        """Test that skip_id parameter works correctly even with errors."""
+        mock_embedding_service = Mock()
+
+        # Only called once (scene 2 is skipped)
+        mock_embedding_service.decode_embedding_from_db.return_value = [0.1, 0.2, 0.3]
+        mock_embedding_service.cosine_similarity.return_value = 0.8
+
+        def builder(**kwargs: Any) -> dict[str, Any]:
+            return {"similarity_score": kwargs["similarity_score"], **kwargs}
+
+        candidates = [
+            {
+                "id": 1,
+                "script_id": 100,
+                "heading": "Scene 1",
+                "content": "Content 1",
+                "_embedding": b"data1",
+            },
+            {
+                "id": 2,  # This will be skipped
+                "script_id": 100,
+                "heading": "Scene 2",
+                "content": "Content 2",
+                "_embedding": b"data2",
+            },
+        ]
+
+        results = build_scene_results(
+            candidates,
+            query_embedding=[0.4, 0.5, 0.6],
+            embedding_service=mock_embedding_service,
+            threshold=0.5,
+            builder=builder,
+            skip_id=2,  # Skip scene with id=2
+        )
+
+        # Should only have scene 1
+        assert len(results) == 1
+        assert results[0]["scene_id"] == 1
+
+    def test_build_results_all_corrupted(self) -> None:
+        """Test that empty list is returned when all embeddings are corrupted."""
+        mock_embedding_service = Mock()
+        mock_embedding_service.decode_embedding_from_db.side_effect = ValueError(
+            "All corrupted"
+        )
+
+        def builder(**kwargs: Any) -> dict[str, Any]:
+            return kwargs
+
+        candidates = [
+            {
+                "id": i,
+                "script_id": 100,
+                "heading": f"Scene {i}",
+                "content": f"Content {i}",
+                "_embedding": b"bad",
+            }
+            for i in range(5)
+        ]
+
+        results = build_scene_results(
+            candidates,
+            query_embedding=[0.1, 0.2],
+            embedding_service=mock_embedding_service,
+            threshold=0.5,
+            builder=builder,
+        )
+
+        assert results == []

--- a/tests/unit/test_semantic_search_decode_error.py
+++ b/tests/unit/test_semantic_search_decode_error.py
@@ -1,0 +1,158 @@
+"""Test error handling for embedding decode errors in semantic search."""
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from scriptrag.api.semantic_search import SemanticSearchService
+from scriptrag.config import ScriptRAGSettings
+
+
+class TestSemanticSearchDecodeError:
+    """Test handling of embedding decode errors in semantic search."""
+
+    @pytest.fixture
+    def semantic_search_service(self, tmp_path: Path) -> SemanticSearchService:
+        """Create a semantic search service for testing."""
+        settings = ScriptRAGSettings(database_path=tmp_path / "test.db")
+        return SemanticSearchService(settings)
+
+    @pytest.mark.asyncio
+    @patch("scriptrag.api.semantic_search.logger")
+    async def test_find_related_scenes_handles_decode_error(
+        self,
+        mock_logger: Mock,
+        semantic_search_service: SemanticSearchService,
+    ) -> None:
+        """Test that find_related_scenes handles decode errors gracefully."""
+        # Mock the database operations
+        with patch.object(semantic_search_service, "db_ops") as mock_db_ops:
+            mock_conn = Mock()
+            mock_db_ops.transaction.return_value.__enter__ = Mock(
+                return_value=mock_conn
+            )
+            mock_db_ops.transaction.return_value.__exit__ = Mock(return_value=None)
+
+            # Mock getting source embedding that will fail to decode
+            mock_db_ops.get_embedding.return_value = b"corrupted_data"
+
+            # Mock embedding service to raise ValueError on decode
+            with patch.object(
+                semantic_search_service, "embedding_service"
+            ) as mock_embedding_service:
+                mock_embedding_service.decode_embedding_from_db.side_effect = (
+                    ValueError(
+                        "Embedding data too short: expected at least 4 bytes, got 3"
+                    )
+                )
+
+                # Call the method
+                results = await semantic_search_service.find_related_scenes(
+                    scene_id=123,
+                    threshold=0.7,
+                    top_k=10,
+                )
+
+                # Should return empty list
+                assert results == []
+
+                # Should log a warning
+                mock_logger.warning.assert_called_once()
+                call_args = mock_logger.warning.call_args
+                assert "Failed to decode source scene embedding" in call_args[0][0]
+                assert call_args[1]["scene_id"] == 123
+                assert "Embedding data too short" in call_args[1]["error"]
+
+    @pytest.mark.asyncio
+    @patch("scriptrag.api.semantic_search.logger")
+    async def test_find_related_scenes_with_valid_then_corrupted(
+        self,
+        mock_logger: Mock,
+        semantic_search_service: SemanticSearchService,
+    ) -> None:
+        """Test handling when source is valid but candidate embeddings are corrupted."""
+        with patch.object(semantic_search_service, "db_ops") as mock_db_ops:
+            mock_conn = Mock()
+            mock_db_ops.transaction.return_value.__enter__ = Mock(
+                return_value=mock_conn
+            )
+            mock_db_ops.transaction.return_value.__exit__ = Mock(return_value=None)
+
+            # Mock getting valid source embedding
+            valid_embedding_bytes = (
+                b"\x03\x00\x00\x00" + b"\x00\x00\x80\x3f" * 3
+            )  # [1.0, 1.0, 1.0]
+            mock_db_ops.get_embedding.return_value = valid_embedding_bytes
+
+            # Mock embedding service
+            with patch.object(
+                semantic_search_service, "embedding_service"
+            ) as mock_embedding_service:
+                # First decode (source) succeeds
+                mock_embedding_service.decode_embedding_from_db.side_effect = [
+                    [1.0, 1.0, 1.0],  # Source decodes successfully
+                    ValueError("Corrupted candidate"),  # First candidate fails
+                    [0.9, 0.9, 0.9],  # Second candidate succeeds
+                ]
+                mock_embedding_service.default_model = "test-model"
+
+                mock_embedding_service.cosine_similarity.return_value = 0.95
+
+                # Mock search results with two candidates
+                mock_db_ops.search_similar_scenes.return_value = [
+                    {
+                        "id": 1,
+                        "script_id": 100,
+                        "heading": "Corrupted Scene",
+                        "content": "This will fail",
+                        "_embedding": b"bad_data",
+                    },
+                    {
+                        "id": 2,
+                        "script_id": 100,
+                        "heading": "Valid Scene",
+                        "content": "This will work",
+                        "_embedding": b"good_data",
+                    },
+                ]
+
+                # Call the method
+                results = await semantic_search_service.find_related_scenes(
+                    scene_id=123,
+                    threshold=0.7,
+                    top_k=10,
+                )
+
+                # Should have one result (the valid one)
+                assert len(results) == 1
+                assert results[0].scene_id == 2
+                assert results[0].heading == "Valid Scene"
+                assert results[0].similarity_score == 0.95
+
+    @pytest.mark.asyncio
+    async def test_integration_with_real_embedding_service(
+        self,
+        semantic_search_service: SemanticSearchService,
+    ) -> None:
+        """Test integration with real embedding service decode validation."""
+        # Create a truly corrupted embedding
+        corrupted_bytes = b"\xff\xff"  # Too short to be valid
+
+        with patch.object(semantic_search_service.db_ops, "transaction") as mock_trans:
+            mock_conn = Mock()
+            mock_trans.return_value.__enter__ = Mock(return_value=mock_conn)
+            mock_trans.return_value.__exit__ = Mock(return_value=None)
+
+            with patch.object(
+                semantic_search_service.db_ops, "get_embedding"
+            ) as mock_get_embedding:
+                mock_get_embedding.return_value = corrupted_bytes
+
+                # This should not raise an exception but return empty results
+                results = await semantic_search_service.find_related_scenes(
+                    scene_id=456,
+                    threshold=0.5,
+                )
+
+                assert results == []


### PR DESCRIPTION
## Summary
- Added comprehensive validation in `decode_embedding_from_db` to prevent crashes from corrupted embedding data
- Added error handling in semantic search to gracefully skip corrupted embeddings
- Added 21 comprehensive unit tests with full patch coverage

## Changes
- **EmbeddingService.decode_embedding_from_db**: Added validation for minimum data length, zero dimension, maximum dimension limit, and data length matching
- **semantic_result_processing.py**: Skip scenes/chunks with corrupted embeddings instead of crashing
- **semantic_search.py**: Return empty results when source embedding decode fails with proper logging
- **Tests**: Added 21 new unit tests covering all edge cases

## Test plan
- [x] Unit tests added for all validation cases
- [x] Error handling tested for corrupted data scenarios
- [x] All tests pass locally
- [x] Linting and type checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)