### PR TITLE
Fix fallback_order handling and add tests for invalid fallback providers

### DIFF
--- a/src/scriptrag/utils/llm_factory.py
+++ b/src/scriptrag/utils/llm_factory.py
@@ -70,7 +70,7 @@ def create_llm_client(
         "Creating LLM client",
         preferred_provider=provider_enum.value if provider_enum else "auto",
         fallback_order=[p.value for p in fallback_enums]
-        if fallback_enums
+        if fallback_enums is not None
         else "default",
         has_github_token=bool(github_token),
         openai_endpoint=openai_endpoint if openai_endpoint else "not configured",

--- a/tests/unit/test_utils_llm_factory.py
+++ b/tests/unit/test_utils_llm_factory.py
@@ -179,6 +179,38 @@ class TestCreateLLMClient:
         )
 
     @patch("scriptrag.utils.llm_factory.get_settings")
+    @patch("scriptrag.utils.llm_factory.logger")
+    def test_create_with_all_invalid_fallback_order(
+        self, mock_logger, mock_get_settings, mock_llm_client
+    ):
+        """Test creating client with all invalid fallback order."""
+        mock_settings = MagicMock()
+        mock_settings.llm_provider = None
+        mock_settings.llm_endpoint = None
+        mock_settings.llm_api_key = None
+        mock_get_settings.return_value = mock_settings
+
+        # All invalid providers should result in empty list
+        fallback_order = ["invalid1", "invalid2", "invalid3"]
+        client = create_llm_client(fallback_order=fallback_order)
+
+        # Should be called with empty list, not None
+        mock_llm_client.assert_called_once_with(
+            preferred_provider=None,
+            fallback_order=[],  # Empty list, not None
+            github_token=None,
+            openai_endpoint=None,
+            openai_api_key=None,
+            timeout=30.0,
+        )
+
+        # Check that logging shows empty list, not "default"
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args
+        # The fallback_order in the log should be [], not "default"
+        assert call_args[1]["fallback_order"] == []
+
+    @patch("scriptrag.utils.llm_factory.get_settings")
     def test_create_with_github_token(self, mock_get_settings, mock_llm_client):
         """Test creating client with GitHub token."""
         mock_settings = MagicMock()


### PR DESCRIPTION
## Summary
- Fixes the handling of `fallback_order` parameter in `create_llm_client` to correctly check for `None` instead of falsy values
- Adds comprehensive unit tests to cover scenarios where all fallback providers are invalid
- Ensures logging reflects the correct fallback order (empty list instead of "default")

## Changes

### Core Fix
- Modified condition in `create_llm_client` to use `if fallback_enums is not None` to avoid incorrect fallback behavior when an empty list is passed

### Tests
- Added `test_create_with_all_invalid_fallback_order` to:
  - Mock settings with no valid LLM provider or endpoint
  - Pass an invalid fallback order list
  - Assert that the client is created with an empty fallback list
  - Verify that logging outputs the empty fallback list instead of the string "default"

## Test plan
- [x] Run unit tests to verify new test coverage
- [x] Confirm that the fallback order is handled correctly when invalid providers are given
- [x] Check that logging accurately reflects the fallback order state

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/fabbe25b-18ff-41e9-843c-8afea8158b35