### PR TITLE
fix: avoid misidentifying location words as time in scene headings

### DIFF
--- a/src/scriptrag/utils/screenplay.py
+++ b/src/scriptrag/utils/screenplay.py
@@ -72,6 +72,9 @@ class ScreenplayUtils:
             return None
 
         heading_upper = heading.upper()
+        last_part = heading_upper.rsplit(" - ", 1)[-1]
+        if re.search(r"\bMIDNIGHT\b", last_part):
+            return "NIGHT"
         time_indicators = [
             "DAY",
             "NIGHT",
@@ -86,16 +89,10 @@ class ScreenplayUtils:
             "SUNSET",
             "SUNRISE",
             "NOON",
-            "MIDNIGHT",
         ]
 
-        # Check if heading ends with time indicator
         for indicator in time_indicators:
-            if heading_upper.endswith(indicator):
-                return indicator
-            if f"- {indicator}" in heading_upper:
-                return indicator
-            if f" {indicator}" in heading_upper.split(" - ")[-1]:
+            if re.search(rf"\b{re.escape(indicator)}\b", last_part):
                 return indicator
 
         return None

--- a/tests/unit/test_utils_screenplay.py
+++ b/tests/unit/test_utils_screenplay.py
@@ -112,6 +112,10 @@ class TestScreenplayUtils:
         assert ScreenplayUtils.extract_time("INT. OFFICE - THE NEXT DAY") == "DAY"
         assert ScreenplayUtils.extract_time("EXT. STREET - THAT NIGHT") == "NIGHT"
 
+    def test_extract_time_ignores_location_words(self):
+        """Time indicators embedded in locations should not be detected."""
+        assert ScreenplayUtils.extract_time("INT. SCHOOL - DAYCARE") is None
+
     def test_parse_scene_heading_empty(self):
         """Test parsing empty scene heading."""
         assert ScreenplayUtils.parse_scene_heading("") == ("", None, None)


### PR DESCRIPTION
## Summary
- handle `MIDNIGHT` as `NIGHT` and match time indicators by word to avoid picking up location names like `DAYCARE`
- add regression test for time parsing when location resembles a time indicator

## Testing
- `pre-commit run --files src/scriptrag/utils/screenplay.py tests/unit/test_utils_screenplay.py`
- `pytest tests/unit/test_utils_screenplay.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a821b351d4833384035f2d75e0cc8b