### PR TITLE
Fix imports of ScreenplayUtils from scriptrag.utils

### DIFF
--- a/src/scriptrag/agents/context_query.py
+++ b/src/scriptrag/agents/context_query.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from scriptrag.config import ScriptRAGSettings, get_logger, get_settings
 from scriptrag.query import ParamSpec, QueryEngine, QuerySpec
-from scriptrag.utils.screenplay import ScreenplayUtils
+from scriptrag.utils import ScreenplayUtils
 
 if TYPE_CHECKING:
     from scriptrag.parser import Script

--- a/src/scriptrag/agents/markdown_agent_analyzer.py
+++ b/src/scriptrag/agents/markdown_agent_analyzer.py
@@ -17,8 +17,7 @@ from scriptrag.agents.context_query import (
 )
 from scriptrag.analyzers.base import BaseSceneAnalyzer
 from scriptrag.config import get_logger
-from scriptrag.utils import get_default_llm_client
-from scriptrag.utils.screenplay import ScreenplayUtils
+from scriptrag.utils import ScreenplayUtils, get_default_llm_client
 
 if TYPE_CHECKING:
     from scriptrag.llm.client import LLMClient

--- a/src/scriptrag/analyzers/embedding.py
+++ b/src/scriptrag/analyzers/embedding.py
@@ -10,8 +10,7 @@ import numpy as np
 
 from scriptrag.analyzers.base import BaseSceneAnalyzer
 from scriptrag.config import get_logger
-from scriptrag.utils import get_default_llm_client
-from scriptrag.utils.screenplay import ScreenplayUtils
+from scriptrag.utils import ScreenplayUtils, get_default_llm_client
 
 if TYPE_CHECKING:
     from scriptrag.llm.client import LLMClient

--- a/src/scriptrag/parser/fountain_processor.py
+++ b/src/scriptrag/parser/fountain_processor.py
@@ -13,7 +13,7 @@ from jouvence.document import (
 
 from scriptrag.config import get_logger
 from scriptrag.parser.fountain_models import Dialogue, Scene
-from scriptrag.utils.screenplay import ScreenplayUtils
+from scriptrag.utils import ScreenplayUtils
 
 logger = get_logger(__name__)
 

--- a/tests/unit/test_utils_screenplay.py
+++ b/tests/unit/test_utils_screenplay.py
@@ -1,6 +1,6 @@
 """Tests for screenplay utilities."""
 
-from scriptrag.utils.screenplay import ScreenplayUtils
+from scriptrag.utils import ScreenplayUtils
 
 
 class TestScreenplayUtils:

--- a/tests/unit/test_utils_screenplay_coverage.py
+++ b/tests/unit/test_utils_screenplay_coverage.py
@@ -2,7 +2,7 @@
 
 import hashlib
 
-from scriptrag.utils.screenplay import ScreenplayUtils
+from scriptrag.utils import ScreenplayUtils
 
 
 class TestScreenplayUtilsCoverage:


### PR DESCRIPTION
## Summary
- Corrects import statements for `ScreenplayUtils` to be imported from `scriptrag.utils` instead of `scriptrag.utils.screenplay`
- Applies this fix across multiple source files and test files to ensure consistency

## Changes

### Source Code
- Updated imports in `context_query.py`, `markdown_agent_analyzer.py`, `embedding.py`, and `fountain_processor.py` to import `ScreenplayUtils` from `scriptrag.utils`

### Tests
- Fixed imports in `test_utils_screenplay.py` and `test_utils_screenplay_coverage.py` to import `ScreenplayUtils` from `scriptrag.utils`

## Test plan
- Existing unit tests for screenplay utilities continue to pass
- Verified no import errors occur related to `ScreenplayUtils` after the change

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/66c82035-caf5-44bb-9a79-13ddee4adddc