### PR TITLE
Fix import path for strip_ansi_codes in test files

### DIFF
--- a/tests/integration/test_cli_db_path.py
+++ b/tests/integration/test_cli_db_path.py
@@ -82,7 +82,7 @@ class TestDbPathOption:
 
     def test_help_shows_db_path_option(self):
         """Test that help text shows --db-path option for all commands."""
-        from tests.cli_fixtures import strip_ansi_codes
+        from tests.utils import strip_ansi_codes
 
         # Test init command help
         result = runner.invoke(app, ["init", "--help"])

--- a/tests/test_scene_cli.py
+++ b/tests/test_scene_cli.py
@@ -13,7 +13,7 @@ from scriptrag.api.scene_models import (
 )
 from scriptrag.cli.main import app
 from scriptrag.parser import Scene
-from tests.cli_fixtures import strip_ansi_codes
+from tests.utils import strip_ansi_codes
 
 runner = CliRunner()
 

--- a/tests/test_scene_cli_extended.py
+++ b/tests/test_scene_cli_extended.py
@@ -14,7 +14,7 @@ from scriptrag.api.scene_models import (
 )
 from scriptrag.cli.main import app
 from scriptrag.parser import Scene
-from tests.cli_fixtures import strip_ansi_codes
+from tests.utils import strip_ansi_codes
 
 runner = CliRunner()
 


### PR DESCRIPTION
## Summary
- Corrects the import statement for `strip_ansi_codes` in multiple test files
- Changes import source from `tests.cli_fixtures` to `tests.utils` to reflect the correct module location

## Changes

### Test Files
- Updated import in `tests/integration/test_cli_db_path.py`
- Updated import in `tests/test_scene_cli.py`
- Updated import in `tests/test_scene_cli_extended.py`

## Test plan
- [x] Run existing tests to ensure no import errors occur
- [x] Verify that `strip_ansi_codes` functions correctly in all affected tests

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/fd668fd3-f086-4757-94f8-3ca71a87f106