### PR TITLE
Refactor analyze API: split large module into helpers, protocols, and results

### DIFF
--- a/src/scriptrag/api/__init__.py
+++ b/src/scriptrag/api/__init__.py
@@ -1,6 +1,7 @@
 """ScriptRAG API module."""
 
-from scriptrag.api.analyze import AnalyzeCommand, AnalyzeResult, FileResult
+from scriptrag.api.analyze import AnalyzeCommand
+from scriptrag.api.analyze_results import AnalyzeResult, FileResult
 from scriptrag.api.database import DatabaseInitializer
 from scriptrag.api.database_operations import DatabaseOperations, ScriptRecord
 from scriptrag.api.index import IndexCommand, IndexOperationResult, IndexResult

--- a/src/scriptrag/api/analyze_helpers.py
+++ b/src/scriptrag/api/analyze_helpers.py
@@ -1,0 +1,154 @@
+"""Helper functions for script analysis operations."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from scriptrag.config import get_logger
+from scriptrag.parser import Scene, Script
+
+logger = get_logger(__name__)
+
+
+def file_needs_update(
+    script: Script, analyzers: list[Any], _file_path: Path | None = None
+) -> bool:
+    """Determine if a screenplay file needs analysis processing.
+
+    Checks whether any scenes in the script need analysis by examining
+    existing metadata and comparing with currently loaded analyzers.
+    Used to skip files that are already up-to-date unless force mode.
+
+    Args:
+        script: Parsed Script object containing scenes with potential metadata
+        analyzers: List of loaded analyzers to check against
+        _file_path: Path to the file (parameter preserved for compatibility
+                   but not currently used in the logic)
+
+    Returns:
+        True if the file contains scenes that need processing by current
+        analyzers, False if all scenes are up-to-date
+
+    Note:
+        Currently checks all scenes in the script. A file needs updating
+        if any scene needs updating according to scene_needs_update().
+    """
+    # Check if any scene needs updating
+    if isinstance(script, Script):
+        for scene in script.scenes:
+            if scene_needs_update(scene, analyzers):
+                return True
+
+    return False
+
+
+def scene_needs_update(scene: Scene, analyzers: list[Any]) -> bool:
+    """Determine if a scene needs analysis processing.
+
+    Checks scene metadata to decide whether analysis should be performed:
+    1. Scenes without any metadata need processing
+    2. Scenes missing 'analyzed_at' timestamp need processing
+    3. Scenes missing results from currently loaded analyzers need processing
+
+    This enables incremental analysis where only new or changed scenes
+    are processed, and new analyzers are run on existing scenes.
+
+    Args:
+        scene: Scene object that may contain existing analysis metadata
+              in its boneyard_metadata attribute
+        analyzers: List of loaded analyzers to check against
+
+    Returns:
+        True if the scene should be processed by the analysis pipeline,
+        False if it's already up-to-date with current analyzer set
+
+    Example:
+        A scene with relationship analysis but no embedding analysis
+        would return True if an embedding analyzer is loaded, enabling
+        incremental processing of just the missing analysis type.
+    """
+    if not isinstance(scene, Scene):
+        return False
+
+    # No metadata yet
+    if scene.boneyard_metadata is None:
+        return True
+
+    # Check if metadata is outdated (e.g., missing analyzer results)
+    metadata = scene.boneyard_metadata
+
+    # Check if analyzed_at exists and is recent
+    if "analyzed_at" not in metadata:
+        return True
+
+    # Check if all registered analyzers have been run
+    if "analyzers" in metadata:
+        existing_analyzers = set(metadata["analyzers"].keys())
+        current_analyzers = {a.name for a in analyzers}
+        if current_analyzers - existing_analyzers:
+            # New analyzers to run
+            return True
+
+    # For now, consider up to date
+    return False
+
+
+async def load_bible_metadata(script_path: Path) -> dict[str, Any] | None:
+    """Load Bible character metadata from database for analyzer context.
+
+    Retrieves character alias data that may have been extracted from
+    script Bible files and stored in the database. This metadata is used
+    by analyzers like the relationships analyzer to identify characters
+    mentioned in scenes.
+
+    The method looks for character data stored under 'bible.characters'
+    in the script's metadata column, which contains the output from
+    Bible character extraction operations.
+
+    Args:
+        script_path: Path to the script file to look up in database
+
+    Returns:
+        Dictionary containing Bible character metadata if found and valid,
+        None if script not in database, no metadata exists, or database
+        errors occur. The format matches BibleCharacterExtractor output.
+
+    Example:
+        >>> metadata = await load_bible_metadata(Path("script.fountain"))
+        >>> if metadata:
+        ...     char_count = len(metadata.get("characters", []))
+        ...     print(f"Found {char_count} Bible characters")
+
+    Note:
+        All database errors are caught and logged as debug messages.
+        Returns None gracefully to allow analysis to continue without
+        Bible character data if database issues occur.
+    """
+    try:
+        # Try to load from database
+        from scriptrag.api.database_operations import DatabaseOperations
+        from scriptrag.config import get_settings
+
+        settings = get_settings()
+        db_ops = DatabaseOperations(settings)
+
+        if not db_ops.check_database_exists():
+            return None
+
+        with db_ops.transaction() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT metadata FROM scripts WHERE file_path = ?",
+                (str(script_path),),
+            )
+            row = cursor.fetchone()
+
+            if row and row[0]:
+                metadata = json.loads(row[0]) if isinstance(row[0], str) else row[0]
+                bible_chars = metadata.get("bible.characters")
+                return bible_chars if isinstance(bible_chars, dict) else None
+
+    except Exception as e:
+        logger.debug(f"Could not load Bible metadata: {e}")
+
+    return None

--- a/src/scriptrag/api/analyze_protocols.py
+++ b/src/scriptrag/api/analyze_protocols.py
@@ -1,0 +1,45 @@
+"""Protocol definitions for script analysis components."""
+
+from typing import Any, Protocol
+
+
+class SceneAnalyzer(Protocol):
+    """Protocol defining the interface for scene analysis components.
+
+    Defines the contract that all scene analyzers must implement to participate
+    in the analysis pipeline. Analyzers receive scene data and return metadata
+    that gets attached to scenes in the Fountain file's boneyard comments.
+
+    The protocol enables pluggable analyzers for different types of scene
+    analysis: character relationships, embeddings, themes, etc.
+
+    Example:
+        >>> class MyAnalyzer:
+        ...     @property
+        ...     def name(self) -> str:
+        ...         return "my_analyzer"
+        ...
+        ...     async def analyze(self, scene: dict) -> dict:
+        ...         return {"analysis": "completed"}
+    """
+
+    async def analyze(self, scene: dict[str, Any]) -> dict[str, Any]:
+        """Analyze a scene and return analysis metadata.
+
+        Args:
+            scene: Dictionary containing scene data with keys like 'content',
+                  'heading', 'dialogue', 'action', 'characters'
+
+        Returns:
+            Dictionary containing analysis results to be stored in scene metadata
+        """
+        ...
+
+    @property
+    def name(self) -> str:
+        """Unique identifier for this analyzer.
+
+        Returns:
+            String name used for metadata storage and analyzer registration
+        """
+        ...

--- a/src/scriptrag/api/analyze_results.py
+++ b/src/scriptrag/api/analyze_results.py
@@ -1,0 +1,73 @@
+"""Result data structures for script analysis operations."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class FileResult:
+    """Result data from analyzing a single screenplay file.
+
+    Tracks the outcome of processing one Fountain file through the analysis
+    pipeline, including whether any scenes were updated and error information.
+    Used for reporting and debugging analysis operations.
+
+    Attributes:
+        path: Path to the Fountain file that was processed
+        updated: True if any scenes in the file were updated with new analysis
+        scenes_updated: Count of individual scenes that received new metadata
+        error: Error message if processing failed, None if successful
+
+    Example:
+        >>> result = FileResult(
+        ...     path=Path("my_script.fountain"),
+        ...     updated=True,
+        ...     scenes_updated=15
+        ... )
+        >>> print(f"Updated {result.scenes_updated} scenes")
+    """
+
+    path: Path
+    updated: bool
+    scenes_updated: int = 0
+    error: str | None = None
+
+
+@dataclass
+class AnalyzeResult:
+    """Aggregated results from analyzing multiple screenplay files.
+
+    Contains outcome data from processing one or more Fountain files through
+    the analysis pipeline. Provides both individual file results and summary
+    statistics for batch operations.
+
+    Attributes:
+        files: List of FileResult objects, one for each processed file
+        errors: List of error messages from failed operations that couldn't
+               be attributed to specific files
+
+    Properties:
+        total_files_updated: Count of files that had at least one scene updated
+        total_scenes_updated: Sum of all scenes updated across all files
+
+    Example:
+        >>> result = AnalyzeResult()
+        >>> result.files.append(FileResult(Path("script1.fountain"), True, 10))
+        >>> result.total_files_updated
+        1
+        >>> result.total_scenes_updated
+        10
+    """
+
+    files: list[FileResult] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def total_files_updated(self) -> int:
+        """Count of files that were updated."""
+        return sum(1 for f in self.files if f.updated)
+
+    @property
+    def total_scenes_updated(self) -> int:
+        """Total count of scenes updated across all files."""
+        return sum(f.scenes_updated for f in self.files)

--- a/tests/integration/test_cli_analyze.py
+++ b/tests/integration/test_cli_analyze.py
@@ -172,7 +172,7 @@ class TestAnalyzeCommand:
         """Test that analyze displays errors correctly."""
         from unittest.mock import AsyncMock, MagicMock
 
-        from scriptrag.api.analyze import AnalyzeResult, FileResult
+        from scriptrag.api.analyze_results import AnalyzeResult, FileResult
 
         # Create a mock result with errors
         mock_result = AnalyzeResult(
@@ -330,7 +330,7 @@ class TestAnalyzeCommand:
         """Test analyze displays relative paths when possible."""
         from unittest.mock import AsyncMock, MagicMock
 
-        from scriptrag.api.analyze import AnalyzeResult, FileResult
+        from scriptrag.api.analyze_results import AnalyzeResult, FileResult
 
         # Use monkeypatch.chdir for safer directory change
         monkeypatch.chdir(temp_fountain_files)
@@ -371,7 +371,7 @@ class TestAnalyzeCommand:
         """Test analyze falls back to absolute path when relative not possible."""
         from unittest.mock import AsyncMock, MagicMock
 
-        from scriptrag.api.analyze import AnalyzeResult, FileResult
+        from scriptrag.api.analyze_results import AnalyzeResult, FileResult
 
         # Create a mock result with a file in a different directory
         mock_result = AnalyzeResult(

--- a/tests/unit/test_analyze_additional_coverage.py
+++ b/tests/unit/test_analyze_additional_coverage.py
@@ -6,12 +6,9 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from scriptrag.api.analyze import (
-    AnalyzeCommand,
-    AnalyzeResult,
-    FileResult,
-    SceneAnalyzer,
-)
+from scriptrag.api.analyze import AnalyzeCommand
+from scriptrag.api.analyze_protocols import SceneAnalyzer
+from scriptrag.api.analyze_results import AnalyzeResult, FileResult
 from scriptrag.api.list import FountainMetadata
 from scriptrag.parser import Scene, Script
 

--- a/tests/unit/test_api_analyze.py
+++ b/tests/unit/test_api_analyze.py
@@ -6,7 +6,8 @@ from unittest.mock import patch
 import pytest
 
 from scriptrag.analyzers.base import BaseSceneAnalyzer
-from scriptrag.api.analyze import AnalyzeCommand, AnalyzeResult, FileResult
+from scriptrag.api.analyze import AnalyzeCommand
+from scriptrag.api.analyze_results import AnalyzeResult, FileResult
 
 
 class MockAnalyzer(BaseSceneAnalyzer):


### PR DESCRIPTION
## Summary
- Refactor the `analyze.py` module by splitting it into smaller, focused modules:
  - `analyze_helpers.py` for helper functions
  - `analyze_protocols.py` for protocol definitions
  - `analyze_results.py` for result data classes
- Update imports and references accordingly in the API and tests
- Improve code organization and maintainability by separating concerns

## Changes

### Core Refactor
- Moved `FileResult` and `AnalyzeResult` dataclasses to `analyze_results.py`
- Moved `SceneAnalyzer` protocol to `analyze_protocols.py`
- Moved helper functions `_file_needs_update`, `_scene_needs_update`, and `_load_bible_metadata` to `analyze_helpers.py` as `file_needs_update`, `scene_needs_update`, and `load_bible_metadata`
- Updated `AnalyzeCommand` to use the new helper functions and imports

### API Module Updates
- Adjusted imports in `src/scriptrag/api/__init__.py` and `analyze.py` to reflect new module structure

### Tests
- Updated test imports to use new modules for `AnalyzeResult`, `FileResult`, and `SceneAnalyzer`

## Test plan
- Existing unit and integration tests updated and passing
- Verified that analysis commands function correctly with refactored code
- No change in external behavior, only internal code organization

This refactor improves code clarity and modularity, facilitating future enhancements and maintenance.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d11e678e-aec0-476e-ae17-a04343fec923