### PR TITLE
Refactor test imports to use cli_fixtures.strip_ansi_codes

### DIFF
--- a/tests/integration/test_cli_db_path.py
+++ b/tests/integration/test_cli_db_path.py
@@ -82,7 +82,7 @@ class TestDbPathOption:
 
     def test_help_shows_db_path_option(self):
         """Test that help text shows --db-path option for all commands."""
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         # Test init command help
         result = runner.invoke(app, ["init", "--help"])

--- a/tests/test_scene_cli.py
+++ b/tests/test_scene_cli.py
@@ -13,7 +13,7 @@ from scriptrag.api.scene_models import (
 )
 from scriptrag.cli.main import app
 from scriptrag.parser import Scene
-from tests.utils import strip_ansi_codes
+from tests.cli_fixtures import strip_ansi_codes
 
 runner = CliRunner()
 

--- a/tests/test_scene_cli_extended.py
+++ b/tests/test_scene_cli_extended.py
@@ -14,7 +14,7 @@ from scriptrag.api.scene_models import (
 )
 from scriptrag.cli.main import app
 from scriptrag.parser import Scene
-from tests.utils import strip_ansi_codes
+from tests.cli_fixtures import strip_ansi_codes
 
 runner = CliRunner()
 


### PR DESCRIPTION
## Summary
- Updated test imports in three test files to use `strip_ansi_codes` from `tests.cli_fixtures` instead of `tests.utils`.

## Changes

### Test Files
- **tests/integration/test_cli_db_path.py**: Changed import of `strip_ansi_codes` to `tests.cli_fixtures`.
- **tests/test_scene_cli.py**: Changed import of `strip_ansi_codes` to `tests.cli_fixtures`.
- **tests/test_scene_cli_extended.py**: Changed import of `strip_ansi_codes` to `tests.cli_fixtures`.

## Test plan
- [x] Run existing tests to ensure no breakage due to import changes.
- [x] Verify that `strip_ansi_codes` functions correctly from the new import location in all affected tests.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ffa6af53-4f1f-45cd-a40b-de02cd64f8cd