### PR TITLE
Complete migration to cli_fixtures.strip_ansi_codes

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -19,7 +19,7 @@ Tests that work perfectly in local development may fail in CI because:
 **Always use the `strip_ansi_codes()` utility function when testing CLI output:**
 
 ```python
-from tests.utils import strip_ansi_codes
+from tests.cli_fixtures import strip_ansi_codes
 
 def test_cli_command(self):
     result = runner.invoke(app, ["command", "--help"])
@@ -33,7 +33,7 @@ def test_cli_command(self):
 ```
 
 ### The Utility
-The `strip_ansi_codes()` function is available in `tests/utils.py`:
+The `strip_ansi_codes()` function is available in `tests/cli_fixtures.py`:
 - Removes all ANSI escape sequences using regex pattern `\x1b\[[0-9;]*m`
 - Returns clean text suitable for string matching
 - Shared across all test files to avoid duplication

--- a/tests/integration/test_cli_analyze.py
+++ b/tests/integration/test_cli_analyze.py
@@ -8,7 +8,7 @@ import pytest
 from typer.testing import CliRunner
 
 from scriptrag.cli.main import app
-from tests.utils import strip_ansi_codes
+from tests.cli_fixtures import strip_ansi_codes
 
 runner = CliRunner()
 

--- a/tests/integration/test_cli_db_path.py
+++ b/tests/integration/test_cli_db_path.py
@@ -82,7 +82,7 @@ class TestDbPathOption:
 
     def test_help_shows_db_path_option(self):
         """Test that help text shows --db-path option for all commands."""
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         # Test init command help
         result = runner.invoke(app, ["init", "--help"])

--- a/tests/integration/test_cli_index.py
+++ b/tests/integration/test_cli_index.py
@@ -9,7 +9,7 @@ from typer.testing import CliRunner
 
 from scriptrag.cli.main import app
 from scriptrag.config import ScriptRAGSettings, set_settings
-from tests.utils import strip_ansi_codes
+from tests.cli_fixtures import strip_ansi_codes
 
 runner = CliRunner()
 

--- a/tests/integration/test_cli_list.py
+++ b/tests/integration/test_cli_list.py
@@ -7,7 +7,7 @@ import pytest
 from typer.testing import CliRunner
 
 from scriptrag.cli import app
-from tests.utils import strip_ansi_codes
+from tests.cli_fixtures import strip_ansi_codes
 
 # Path to fixture files
 FIXTURES_DIR = Path(__file__).parent.parent / "fixtures" / "fountain"

--- a/tests/integration/test_cli_query.py
+++ b/tests/integration/test_cli_query.py
@@ -7,7 +7,7 @@ import pytest
 from typer.testing import CliRunner
 
 from scriptrag.cli.main import app
-from tests.utils import strip_ansi_codes
+from tests.cli_fixtures import strip_ansi_codes
 
 
 class TestQueryCLI:

--- a/tests/integration/test_context_query.py
+++ b/tests/integration/test_context_query.py
@@ -13,7 +13,7 @@ from typer.testing import CliRunner
 
 from scriptrag.cli.main import app
 from scriptrag.config import set_settings
-from tests.utils import strip_ansi_codes
+from tests.cli_fixtures import strip_ansi_codes
 
 runner = CliRunner()
 

--- a/tests/integration/test_full_workflow.py
+++ b/tests/integration/test_full_workflow.py
@@ -19,13 +19,13 @@ from typer.testing import CliRunner
 
 from scriptrag.cli.main import app
 from scriptrag.config import set_settings
+from tests.cli_fixtures import strip_ansi_codes
 from tests.llm_fixtures import create_llm_completion_response
 from tests.llm_test_utils import (
     TIMEOUT_INTEGRATION,
     TIMEOUT_LLM,
     retry_flaky_test,
 )
-from tests.utils import strip_ansi_codes
 
 runner = CliRunner()
 

--- a/tests/integration/test_scene_management.py
+++ b/tests/integration/test_scene_management.py
@@ -6,7 +6,7 @@ import pytest
 from typer.testing import CliRunner
 
 from scriptrag.cli.main import app
-from tests.utils import strip_ansi_codes
+from tests.cli_fixtures import strip_ansi_codes
 
 runner = CliRunner()
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,7 +14,7 @@ from typer.testing import CliRunner
 from scriptrag.cli.main import app
 from scriptrag.config import ScriptRAGSettings, set_settings
 from scriptrag.parser import FountainParser
-from tests.utils import strip_ansi_codes
+from tests.cli_fixtures import strip_ansi_codes
 
 runner = CliRunner()
 

--- a/tests/test_scene_cli.py
+++ b/tests/test_scene_cli.py
@@ -13,7 +13,7 @@ from scriptrag.api.scene_models import (
 )
 from scriptrag.cli.main import app
 from scriptrag.parser import Scene
-from tests.utils import strip_ansi_codes
+from tests.cli_fixtures import strip_ansi_codes
 
 runner = CliRunner()
 

--- a/tests/test_scene_cli_extended.py
+++ b/tests/test_scene_cli_extended.py
@@ -14,7 +14,7 @@ from scriptrag.api.scene_models import (
 )
 from scriptrag.cli.main import app
 from scriptrag.parser import Scene
-from tests.utils import strip_ansi_codes
+from tests.cli_fixtures import strip_ansi_codes
 
 runner = CliRunner()
 

--- a/tests/unit/test_cli_commands_analyze.py
+++ b/tests/unit/test_cli_commands_analyze.py
@@ -50,7 +50,7 @@ class TestAnalyzeCommand:
         result = runner.invoke(app, ["analyze", "--help"])
         assert result.exit_code == 0
         # Strip ANSI codes for help output checks
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
         assert "Analyze Fountain files and update their metadata" in output
@@ -85,7 +85,7 @@ class TestAnalyzeCommand:
         result = runner.invoke(app, ["analyze"])
 
         # Verify success - strip ANSI codes for consistent testing
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
         assert result.exit_code == 0
@@ -276,7 +276,7 @@ class TestAnalyzeCommand:
         result = runner.invoke(app, ["analyze", "--analyzer", "bad-analyzer"])
 
         # Verify command still succeeds but shows warning - strip ANSI codes
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
         assert result.exit_code == 0
@@ -336,7 +336,7 @@ class TestAnalyzeCommand:
         result = runner.invoke(app, ["analyze"])
 
         # Verify success with appropriate messaging - strip ANSI codes
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
         assert result.exit_code == 0
@@ -368,7 +368,7 @@ class TestAnalyzeCommand:
         result = runner.invoke(app, ["analyze"])
 
         # Verify command completes successfully despite errors
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
 
@@ -398,7 +398,7 @@ class TestAnalyzeCommand:
         result = runner.invoke(app, ["analyze"])
 
         # Verify error summary
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
 
@@ -437,7 +437,7 @@ class TestAnalyzeCommand:
         # Verify path display - strip ANSI codes and handle Windows paths
         import os
 
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
         assert result.exit_code == 0
@@ -542,7 +542,7 @@ class TestAnalyzeCommand:
         result = runner.invoke(app, ["analyze"])
 
         # Verify spinner was shown (progress task created) - strip ANSI codes
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
         assert result.exit_code == 0

--- a/tests/unit/test_cli_commands_mcp.py
+++ b/tests/unit/test_cli_commands_mcp.py
@@ -32,7 +32,7 @@ class TestMCPCommand:
         assert result.exit_code == 0
 
         # Strip ANSI codes for help output checks
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
         assert "Run the ScriptRAG MCP (Model Context Protocol) server" in output
@@ -363,7 +363,7 @@ class TestMCPCommandIntegration:
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
 
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
 

--- a/tests/unit/test_cli_commands_pull.py
+++ b/tests/unit/test_cli_commands_pull.py
@@ -294,7 +294,7 @@ class TestPullCommand:
         result = runner.invoke(app, ["pull"])
 
         # Verify completion despite errors
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
         assert result.exit_code == 0
@@ -569,7 +569,7 @@ class TestPullCommand:
         result = runner.invoke(app, ["pull"])
 
         # Verify error display
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
         assert result.exit_code == 0

--- a/tests/unit/test_cli_commands_scene.py
+++ b/tests/unit/test_cli_commands_scene.py
@@ -16,7 +16,7 @@ from scriptrag.api.scene_models import (
 )
 from scriptrag.cli.main import app
 from scriptrag.parser import Scene
-from tests.utils import strip_ansi_codes
+from tests.cli_fixtures import strip_ansi_codes
 
 
 class TestSceneCommandsConfigOption:

--- a/tests/unit/test_cli_commands_watch.py
+++ b/tests/unit/test_cli_commands_watch.py
@@ -100,7 +100,7 @@ class TestWatchCommand:
         )
 
         # Verify timeout behavior
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
         assert "Watch timeout reached (3s)" in output
@@ -535,7 +535,7 @@ class TestWatchCommand:
                 )
 
                 # Verify timeout message
-                from tests.utils import strip_ansi_codes
+                from tests.cli_fixtures import strip_ansi_codes
 
                 output = strip_ansi_codes(result.output)
                 assert "Watch timeout reached (4s)" in output
@@ -633,7 +633,7 @@ class TestWatchCommand:
         tmp_path,
     ):
         """Test watch command with non-existent config file."""
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         # Use non-existent config file
         config_file = tmp_path / "nonexistent.yaml"

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -84,7 +84,7 @@ class TestCommandRegistration:
     )
     def test_command_help_accessible(self, command):
         """Test that help is accessible for all commands."""
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         runner = CliRunner()
         result = runner.invoke(app, [command, "--help"])

--- a/tests/unit/test_cli_main_comprehensive.py
+++ b/tests/unit/test_cli_main_comprehensive.py
@@ -33,7 +33,7 @@ class TestCLIMainApp:
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
 
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
 
@@ -63,7 +63,7 @@ class TestCLIMainApp:
 
         # Test more safely by checking it doesn't appear in main help
         result = runner.invoke(app, ["--help"])
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
 
@@ -77,7 +77,7 @@ class TestCLIMainApp:
         result = runner.invoke(app, ["query", "--help"])
         assert result.exit_code == 0
 
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
 
@@ -150,7 +150,7 @@ class TestCLIMainModuleIntegration:
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
 
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
 
@@ -174,7 +174,7 @@ class TestCLIMainModuleIntegration:
             result = runner.invoke(app, [command, "--help"])
             # Some commands might exit with code != 0 due to missing deps,
             # but help should generally work
-            from tests.utils import strip_ansi_codes
+            from tests.cli_fixtures import strip_ansi_codes
 
             output = strip_ansi_codes(result.output)
 
@@ -240,7 +240,7 @@ class TestCLIMainEdgeCases:
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
 
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
 
@@ -287,7 +287,7 @@ class TestCLIMainEdgeCases:
     def test_command_name_consistency(self, runner):
         """Test that command names are consistent."""
         result = runner.invoke(app, ["--help"])
-        from tests.utils import strip_ansi_codes
+        from tests.cli_fixtures import strip_ansi_codes
 
         output = strip_ansi_codes(result.output)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,15 +7,37 @@ to the new cli_fixtures module for automatic ANSI stripping.
 import contextlib
 import json
 import sqlite3
+
+# Import strip_ansi_codes from the new module for consistency
+import warnings
 from pathlib import Path
 from typing import Any
 
 from typer.testing import CliRunner
 
 from scriptrag.cli.main import app
+from tests.cli_fixtures import strip_ansi_codes as _strip_ansi_codes
 
-# Import strip_ansi_codes from the new module for consistency
-from tests.cli_fixtures import strip_ansi_codes
+
+def strip_ansi_codes(text: str) -> str:
+    """Strip ANSI escape codes from text.
+
+    DEPRECATED: Import directly from tests.cli_fixtures instead.
+    This wrapper will be removed in a future version.
+
+    Args:
+        text: Text containing ANSI escape codes
+
+    Returns:
+        Text with ANSI codes removed
+    """
+    warnings.warn(
+        "Importing strip_ansi_codes from tests.utils is deprecated. "
+        "Please import directly from tests.cli_fixtures instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _strip_ansi_codes(text)
 
 
 class CLITestHelper:
@@ -38,7 +60,7 @@ class CLITestHelper:
             Tuple of (exit_code, cleaned_output)
         """
         result = self.runner.invoke(app, ["init", "--db-path", str(self.db_path)])
-        return result.exit_code, strip_ansi_codes(result.stdout)
+        return result.exit_code, _strip_ansi_codes(result.stdout)
 
     def analyze_scripts(
         self, script_dir: Path, analyzer: str | None = None, force: bool = False
@@ -60,7 +82,7 @@ class CLITestHelper:
             args.append("--force")
 
         result = self.runner.invoke(app, args)
-        return result.exit_code, strip_ansi_codes(result.stdout)
+        return result.exit_code, _strip_ansi_codes(result.stdout)
 
     def index_scripts(self, script_dir: Path) -> tuple[int, str]:
         """Run the index command on a directory.
@@ -72,7 +94,7 @@ class CLITestHelper:
             Tuple of (exit_code, cleaned_output)
         """
         result = self.runner.invoke(app, ["index", str(script_dir)])
-        return result.exit_code, strip_ansi_codes(result.stdout)
+        return result.exit_code, _strip_ansi_codes(result.stdout)
 
     def search(self, query: str, **kwargs) -> tuple[int, str, dict[str, Any] | None]:
         """Run a search query.
@@ -93,7 +115,7 @@ class CLITestHelper:
             args.extend(["--offset", str(kwargs["offset"])])
 
         result = self.runner.invoke(app, args)
-        output = strip_ansi_codes(result.stdout)
+        output = _strip_ansi_codes(result.stdout)
 
         json_data = None
         if kwargs.get("json") and result.exit_code == 0:


### PR DESCRIPTION
## Summary

This PR completes the migration recommended in PR #356's review by migrating all remaining test files to import `strip_ansi_codes` directly from `tests.cli_fixtures`.

## Changes

- ✅ **Migrated 16 test files** from `tests.utils` to `tests.cli_fixtures` import
- ✅ **Updated documentation** in `tests/CLAUDE.md` to reflect new import location
- ✅ **Added deprecation warning** to `tests.utils.strip_ansi_codes` wrapper
- ✅ **Internal CLITestHelper** uses direct import to avoid deprecation warnings

## Files Changed

### Test Files Migrated (16 files)
- `tests/integration/test_cli_analyze.py`
- `tests/integration/test_cli_index.py`
- `tests/integration/test_cli_list.py`
- `tests/integration/test_cli_query.py`
- `tests/integration/test_context_query.py`
- `tests/integration/test_full_workflow.py`
- `tests/integration/test_scene_management.py`
- `tests/test_integration.py`
- `tests/unit/test_cli_commands_analyze.py`
- `tests/unit/test_cli_commands_mcp.py`
- `tests/unit/test_cli_commands_pull.py`
- `tests/unit/test_cli_commands_scene.py`
- `tests/unit/test_cli_commands_watch.py`
- `tests/unit/test_cli_main.py`
- `tests/unit/test_cli_main_comprehensive.py`

### Documentation & Utils Updated
- `tests/CLAUDE.md` - Updated import examples and documentation
- `tests/utils.py` - Added deprecation warning and updated internal usage

## Testing

All tests pass with the new import structure. The migration is backward compatible through the deprecation wrapper.

## Related

- Completes the recommendations from PR #356
- Follows the architecture documented in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.ai/code)