### PR TITLE
Add structured logging for corrupted semantic result embeddings

### DIFF
--- a/src/scriptrag/api/semantic_result_processing.py
+++ b/src/scriptrag/api/semantic_result_processing.py
@@ -11,6 +11,10 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable
 from typing import Any
 
+from scriptrag.config import get_logger
+
+logger = get_logger(__name__)
+
 
 def build_scene_results(
     candidates: Iterable[dict[str, Any]],
@@ -38,9 +42,16 @@ def build_scene_results(
             scene_embedding = embedding_service.decode_embedding_from_db(
                 scene["_embedding"]
             )
-        except (ValueError, KeyError):
+        except (ValueError, KeyError) as e:
             # Skip scenes with corrupted or missing embeddings
-            # Log would be here if we had logger access
+            logger.warning(
+                "Skipping scene with corrupted or missing embedding",
+                scene_id=scene.get("id"),
+                script_id=scene.get("script_id"),
+                heading=scene.get("heading"),
+                error_type=type(e).__name__,
+                error=str(e),
+            )
             continue
 
         similarity = embedding_service.cosine_similarity(
@@ -84,9 +95,18 @@ def build_bible_results(
             chunk_embedding = embedding_service.decode_embedding_from_db(
                 chunk["embedding"]
             )
-        except (ValueError, KeyError):
+        except (ValueError, KeyError) as e:
             # Skip chunks with corrupted or missing embeddings
-            # Log would be here if we had logger access
+            logger.warning(
+                "Skipping bible chunk with corrupted or missing embedding",
+                chunk_id=chunk.get("id"),
+                bible_id=chunk.get("bible_id"),
+                script_id=chunk.get("script_id"),
+                bible_title=chunk.get("bible_title"),
+                heading=chunk.get("heading"),
+                error_type=type(e).__name__,
+                error=str(e),
+            )
             continue
 
         similarity = embedding_service.cosine_similarity(


### PR DESCRIPTION
## Summary
- Introduces structured logging for handling corrupted or missing embeddings in semantic result processing
- Logs detailed context including IDs, headings, and error information for easier debugging

## Changes

### Semantic Result Processing
- Added logger initialization using `get_logger` from config
- Enhanced exception handling in `build_scene_results` and `build_bible_results` to log warnings with structured metadata:
  - Scene or chunk IDs
  - Script or bible IDs
  - Headings and titles
  - Error type and message

## Test plan
- Verified that corrupted or missing embeddings trigger warning logs with detailed context
- Confirmed normal processing continues without interruption after logging warnings

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/35f7d3ed-aa71-46db-9f19-c7811608c2f5