### PR TITLE
Make Bible LLM context size configurable via settings

### DIFF
--- a/src/scriptrag/api/bible_alias_extractor.py
+++ b/src/scriptrag/api/bible_alias_extractor.py
@@ -57,9 +57,9 @@ class BibleAliasExtractor:
             client = await get_default_llm_client()
 
             # Concatenate relevant chunks into a single prompt context (bounded)
-            # Keep it lightweight: headings + first 2000 chars
+            # Keep it lightweight: headings + first N chars (configurable)
             chunks_text = []
-            limit = 2000
+            limit = self.settings.bible_llm_context_limit
             total = 0
             for ch in parsed_bible.chunks:
                 frag = f"# {ch.heading or ''}\n\n{ch.content}\n\n"

--- a/src/scriptrag/config/settings.py
+++ b/src/scriptrag/config/settings.py
@@ -204,6 +204,13 @@ class ScriptRAGSettings(BaseSettings):
         description="Maximum size for bible files in bytes",
         gt=0,
     )
+    bible_llm_context_limit: int = Field(
+        default=2000,
+        description=(
+            "Maximum character limit for LLM context when extracting bible aliases"
+        ),
+        gt=0,
+    )
 
     @field_validator("database_path", "log_file", mode="before")
     @classmethod


### PR DESCRIPTION
## Summary
- Introduces a configurable character limit for the LLM context when extracting Bible aliases
- Replaces hardcoded 2000 character limit with a setting `bible_llm_context_limit` in the configuration

## Changes

### Configuration
- Added `bible_llm_context_limit` integer field to `ScriptRAGSettings` with a default value of 2000
- This setting controls the maximum number of characters included in the LLM context for Bible alias extraction

### Bible Alias Extractor
- Updated context concatenation logic to use the configurable `bible_llm_context_limit` instead of a fixed 2000 character limit
- This allows more flexible control over the prompt size sent to the LLM client

## Test plan
- Verify that the default limit of 2000 characters is applied when no custom setting is provided
- Test changing the `bible_llm_context_limit` setting to different values and confirm the context size respects the new limit
- Ensure no regressions in Bible alias extraction functionality with the new configurable limit

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/eda7fa06-1e2a-48a6-82ee-9948985dbdd0