### PR TITLE
Remove Python 3.11 UTC compatibility fallback in tests

### DIFF
--- a/tests/unit/test_mcp_tools_scene.py
+++ b/tests/unit/test_mcp_tools_scene.py
@@ -1,6 +1,6 @@
 """Unit tests for MCP scene management tools."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -14,12 +14,6 @@ from scriptrag.api.scene_models import (
 )
 from scriptrag.mcp.tools.scene import register_scene_tools
 from scriptrag.parser import Scene
-
-# Python 3.11 compatibility for UTC
-try:
-    from datetime import UTC
-except ImportError:
-    UTC = timezone.utc  # noqa: UP017
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Cleans up unit test imports by removing Python 3.11 compatibility fallback for UTC
- Uses direct import of `UTC` from `datetime` instead of fallback to `timezone.utc`

## Changes

### Tests
- Updated `tests/unit/test_mcp_tools_scene.py`:
  - Removed try-except block that provided compatibility for `UTC` in Python versions before 3.11
  - Changed import statement to directly import `UTC` from `datetime`

## Test plan
- Run existing unit tests to ensure no regressions
- Confirm that tests pass with Python 3.11+ environments where `datetime.UTC` is available

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b119a7e5-df3e-4068-a350-592f8e154e42