### PR TITLE
Remove backward compatibility exports and clean up imports

### DIFF
--- a/src/scriptrag/api/__init__.py
+++ b/src/scriptrag/api/__init__.py
@@ -15,7 +15,7 @@ from scriptrag.api.analyze_results import AnalyzeResult as AnalyzeResult
 from scriptrag.api.analyze_results import FileResult as FileResult
 from scriptrag.api.database import DatabaseInitializer as DatabaseInitializer
 from scriptrag.api.database_operations import DatabaseOperations as DatabaseOperations
-from scriptrag.api.database_operations import ScriptRecord as ScriptRecord
+from scriptrag.api.db_script_ops import ScriptRecord as ScriptRecord
 from scriptrag.api.index import IndexCommand as IndexCommand
 from scriptrag.api.index import IndexOperationResult as IndexOperationResult
 from scriptrag.api.index import IndexResult as IndexResult

--- a/src/scriptrag/api/database_operations.py
+++ b/src/scriptrag/api/database_operations.py
@@ -18,8 +18,7 @@ from scriptrag.api.db_script_ops import ScriptOperations, ScriptRecord
 from scriptrag.config import ScriptRAGSettings
 from scriptrag.parser import Dialogue, Scene, Script
 
-# Re-export ScriptRecord for backward compatibility
-__all__ = ["DatabaseOperations", "ScriptRecord"]
+__all__ = ["DatabaseOperations"]
 
 
 class DatabaseOperations:

--- a/src/scriptrag/query/loader.py
+++ b/src/scriptrag/query/loader.py
@@ -35,7 +35,7 @@ class QueryLoader:
             file_extension="sql",
         )
 
-        # For backward compatibility
+        # Initialize query directory for tests
         self._query_dir = self._get_query_directory()
 
     def _get_query_directory(self) -> Path:
@@ -69,7 +69,7 @@ class QueryLoader:
         return default_path
 
     def _is_query_dir_explicitly_set(self) -> bool:
-        """Check if _query_dir was explicitly overridden (e.g., by tests).
+        """Check if _query_dir was explicitly overridden by tests.
 
         Returns:
             True if _query_dir was set to something other than the default resolver path

--- a/tests/cli_fixtures.py
+++ b/tests/cli_fixtures.py
@@ -366,7 +366,7 @@ def with_clean_output(func: Callable) -> Callable:
     return wrapper
 
 
-# Export the strip_ansi_codes function for backward compatibility
+# Export public test fixtures and utilities
 __all__ = [
     "CleanCliRunner",
     "CleanResult",

--- a/tests/unit/test_database_operations_coverage.py
+++ b/tests/unit/test_database_operations_coverage.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 import pytest
 
-from scriptrag.api.database_operations import DatabaseOperations, ScriptRecord
+from scriptrag.api.database_operations import DatabaseOperations
+from scriptrag.api.db_script_ops import ScriptRecord
 from scriptrag.config import ScriptRAGSettings
 
 


### PR DESCRIPTION
## Summary
- Removed backward compatibility exports for `ScriptRecord` from `database_operations.py`.
- Updated imports to use `ScriptRecord` from the new `db_script_ops` module.
- Cleaned up comments and docstrings related to backward compatibility.
- Adjusted test imports accordingly.

## Changes

### API Module
- Changed import of `ScriptRecord` in `src/scriptrag/api/__init__.py` to import from `db_script_ops` instead of `database_operations`.
- Removed `ScriptRecord` from `__all__` in `database_operations.py` to drop backward compatibility export.

### Query Loader
- Updated comments in `query/loader.py` to remove references to backward compatibility.

### Tests
- Updated imports in `test_database_operations_coverage.py` to import `ScriptRecord` from `db_script_ops`.
- Cleaned up export comments in `cli_fixtures.py` to reflect current public fixtures and utilities.

## Test plan
- Verified that tests in `test_database_operations_coverage.py` pass with updated imports.
- Ensured no references to backward compatibility exports remain in the codebase.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4912523c-7ebe-4055-b42f-ee233d6b8d85