### PR TITLE
docs: update semantic search docs to remove vector_db import

### DIFF
--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -380,18 +380,26 @@ class CustomEmbeddingService(EmbeddingService):
 
 ### Vector Database Integration
 
-For production deployments with millions of scenes, consider integrating a dedicated vector database:
+ScriptRAG's semantic search uses an embedded SQLite database with vector similarity search capabilities. The architecture is designed to be extensible for future integration with dedicated vector databases:
 
 ```python
-# Future support for vector databases
-from scriptrag.vector_db import ChromaDBAdapter, PineconeAdapter
+# Current semantic search implementation
+from scriptrag.api.semantic_search import SemanticSearchService
+from scriptrag.config import get_settings
 
-# Configure vector database
-vector_db = ChromaDBAdapter(
-    collection="screenplay_scenes",
-    distance_metric="cosine"
+# Configure semantic search service
+settings = get_settings()
+search_service = SemanticSearchService(settings)
+
+# Search for similar scenes
+results = await search_service.search_similar_scenes(
+    query="scenes about betrayal",
+    top_k=10,
+    threshold=0.5
 )
 ```
+
+For production deployments with millions of scenes, future releases may support dedicated vector databases like ChromaDB or Pinecone through the extensible `SemanticSearchService` interface.
 
 ## Conclusion
 


### PR DESCRIPTION
## Summary
- Updated semantic search documentation to remove deprecated vector_db imports
- Clarified current implementation uses embedded SQLite with vector similarity search
- Added notes on future extensibility for dedicated vector databases like ChromaDB and Pinecone

## Changes

### Documentation
- Removed import statements for `ChromaDBAdapter` and `PineconeAdapter` from example code
- Replaced with current usage of `SemanticSearchService` and configuration via `get_settings()`
- Updated example code to demonstrate semantic search with embedded SQLite vector search
- Added explanation about future support for dedicated vector databases through extensible interface

## Test plan
- Verified documentation changes for clarity and accuracy
- Ensured example code is consistent with current implementation
- Confirmed no references to removed vector_db imports remain in docs

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a20147cb-026b-48af-8349-95f6760f8baf