### PR TITLE
Add pre-commit hook to block committing .env files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -170,6 +170,30 @@ repos:
           fi'
         language: system
         pass_filenames: false
+      - id: block-env-files
+        name: Block .env files from being committed
+        entry: |
+          bash -c 'if git diff --cached --name-only | grep -E "^\.env(\..*)?$" > /dev/null; then
+            echo "";
+            echo "❌ ERROR: Attempting to commit .env file(s)!";
+            echo "";
+            echo "Environment files contain sensitive information and must NEVER be committed.";
+            echo "The following .env file(s) were blocked:";
+            git diff --cached --name-only | grep -E "^\.env(\..*)?$" | sed "s/^/  - /";
+            echo "";
+            echo "To fix this:";
+            echo "  1. Remove the file(s) from staging: git reset HEAD .env*";
+            echo "  2. Ensure .env is in your .gitignore file";
+            echo "  3. Use .env.example for sharing configuration templates";
+            echo "";
+            echo "If you have already committed .env files, remove them from history:";
+            echo "  git rm --cached .env";
+            echo "";
+            exit 1;
+          fi'
+        language: system
+        pass_filenames: false
+        always_run: true
 
 ci:
   autoupdate_schedule: weekly


### PR DESCRIPTION
## Summary
- Adds a pre-commit hook to prevent committing `.env` files
- Ensures sensitive environment files are never committed to the repository
- Provides clear error messages and instructions when `.env` files are detected in staged changes

## Changes

### Pre-commit Configuration
- Added a new hook `block-env-files` in `.pre-commit-config.yaml`
- The hook runs a bash script that checks for `.env` files in the staged changes
- If `.env` files are found, the commit is blocked with an error message explaining:
  - Why `.env` files should not be committed
  - Which files were detected
  - How to fix the issue (unstage files, add to `.gitignore`, use `.env.example`)
  - How to remove `.env` files from history if already committed

## Test plan
- [x] Stage a `.env` file and attempt to commit, verify the commit is blocked
- [x] Verify the error message and instructions are clear and accurate
- [x] Stage other files and commit successfully to ensure no false positives

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7c53aa3f-a70a-40bb-8ce6-d12fc98c66ba