### PR TITLE
Update logging configuration docs and .env.example for new log formats

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,8 +80,11 @@ SCRIPTRAG_LLM_BATCH_SIZE=32
 # Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 SCRIPTRAG_LOG_LEVEL=INFO
 
-# Log format (structured, json, plain)
-SCRIPTRAG_LOG_FORMAT=structured
+# Log format (console, json, structured)
+# - console: Human-readable output with colors (best for development, default)
+# - json: Machine-readable JSON format (best for log aggregation systems)
+# - structured: Key-value pairs (good for production debugging)
+SCRIPTRAG_LOG_FORMAT=console
 
 # Path to log file (leave empty for console only)
 # SCRIPTRAG_LOG_FILE_PATH=./logs/scriptrag.log
@@ -91,9 +94,6 @@ SCRIPTRAG_LOG_MAX_FILE_SIZE=10485760
 
 # Number of backup log files to keep
 SCRIPTRAG_LOG_BACKUP_COUNT=5
-
-# Whether to output logs in JSON format (true/false)
-SCRIPTRAG_LOG_JSON_LOGS=false
 
 # Log level for SQLAlchemy (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 SCRIPTRAG_LOG_SQLALCHEMY_LEVEL=WARNING
@@ -198,12 +198,13 @@ SCRIPTRAG_PATH_EXPORTS_DIR=./exports
 # SCRIPTRAG_ENVIRONMENT=development
 # SCRIPTRAG_DEBUG=true
 # SCRIPTRAG_LOG_LEVEL=DEBUG
+# SCRIPTRAG_LOG_FORMAT=console
 
 # Production environment with JSON logging and file output:
 # SCRIPTRAG_ENVIRONMENT=production
 # SCRIPTRAG_DEBUG=false
 # SCRIPTRAG_LOG_LEVEL=INFO
-# SCRIPTRAG_LOG_JSON_LOGS=true
+# SCRIPTRAG_LOG_FORMAT=json
 # SCRIPTRAG_LOG_FILE_PATH=./logs/scriptrag.log
 
 # Custom LLM endpoint (e.g., OpenAI):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,10 +83,29 @@ ScriptRAG follows consistent naming conventions across different configuration s
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `log_level` | str | `INFO` | Logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL) |
-| `log_format` | str | `console` | Output format (console/JSON/structured) |
+| `log_format` | str | `console` | Output format - see below for details |
 | `log_file` | Path | `null` | Optional log file path |
 | `log_file_rotation` | str | `1 day` | Log rotation interval |
 | `log_file_retention` | str | `7 days` | Log retention period |
+
+#### Log Format Options
+
+ScriptRAG supports three logging formats to suit different environments:
+
+- **`console`** (default) - Human-readable output with colors, ideal for development
+  - Colored output when connected to a terminal
+  - Clear, easy-to-read format for debugging
+  - Best for local development and interactive use
+
+- **`json`** - Machine-readable JSON format, ideal for production
+  - Each log entry as a JSON object
+  - Perfect for log aggregation systems (ELK, Splunk, etc.)
+  - Includes structured metadata for filtering and searching
+
+- **`structured`** - Key-value pairs format, good for production debugging
+  - Readable yet parseable format
+  - Balance between human and machine readability
+  - Useful when you need both visibility and structure
 
 ### Search Settings
 
@@ -319,6 +338,31 @@ EOF
 
 # Load both (prod.yaml overrides base.yaml)
 uv run scriptrag pull --config base.yaml --config prod.yaml
+```
+
+### Example 5: Logging Configuration
+
+```bash
+# Development setup with console logging
+export SCRIPTRAG_LOG_FORMAT=console
+export SCRIPTRAG_LOG_LEVEL=DEBUG
+uv run scriptrag pull screenplay.fountain
+
+# Production setup with JSON logging to file
+cat > prod-config.yaml << EOF
+log_format: json
+log_level: INFO
+log_file: /var/log/scriptrag/app.log
+EOF
+uv run scriptrag pull --config prod-config.yaml screenplay.fountain
+
+# Docker container with structured logging
+docker run -e SCRIPTRAG_LOG_FORMAT=structured \
+           -e SCRIPTRAG_LOG_LEVEL=INFO \
+           scriptrag:latest
+
+# Quick debugging with verbose output
+SCRIPTRAG_LOG_LEVEL=DEBUG SCRIPTRAG_LOG_FORMAT=console uv run scriptrag search "dialogue"
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- Enhances `.env.example` with updated logging format options and descriptions
- Expands `docs/configuration.md` to detail three logging formats: console, json, and structured
- Adds example usage scenarios for different logging configurations in the documentation

## Changes

### .env.example
- Updated `SCRIPTRAG_LOG_FORMAT` default to `console` with detailed comments on available formats
- Removed deprecated `SCRIPTRAG_LOG_JSON_LOGS` setting
- Provided example environment variable setups for development and production logging

### Documentation (`docs/configuration.md`)
- Added a new section "Log Format Options" explaining the three supported logging formats:
  - `console`: human-readable with colors, ideal for development
  - `json`: machine-readable JSON, ideal for production log aggregation
  - `structured`: key-value pairs, balancing readability and structure
- Included example commands demonstrating how to configure logging for different environments (development, production, Docker, quick debugging)

## Test plan
- Verify `.env.example` reflects accurate and clear logging configuration options
- Confirm documentation renders correctly with new logging format details and examples
- Test example commands to ensure they work as intended in respective environments

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ff296979-58ab-4415-855d-82216f867a80