### PR TITLE
feat: add local canary test target for quick validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 coverage.xml
 coverage.json
 junit.xml
+junit-canary.xml
 *.cover
 *.py,cover
 .hypothesis/

--- a/README.md
+++ b/README.md
@@ -189,6 +189,48 @@ uv run scriptrag scene read --project "My Amazing Script" --scene 1
 | `search` | Search scripts | ✅ Working |
 | `query` | Run SQL queries | ✅ Working |
 
+## 🧪 Development & Testing
+
+### Quick Validation
+
+Use the canary test target for rapid validation before pushing changes:
+
+```bash
+# Run canary tests (< 30 seconds) - mimics CI's quick validation
+make test-canary
+
+# Run fast checks + canary tests (recommended before push)
+make check-canary
+```
+
+The canary tests:
+
+- Skip integration, slow, and LLM tests
+- Fail fast on first error
+- Limit to 10 failures maximum
+- Timeout tests after 15 seconds
+- Complete in under 30 seconds
+
+### Complete Testing
+
+```bash
+# Run full test suite with coverage
+make test
+
+# Run specific test types
+make test-unit         # Unit tests only
+make test-integration  # Integration tests
+make test-llm         # LLM tests (requires SCRIPTRAG_TEST_LLMS=1)
+
+# Quick tests without coverage
+make test-fast
+
+# Run all quality checks (lint, type-check, security, tests)
+make check
+```
+
+See [Testing Best Practices](docs/TESTING.md) for comprehensive testing guidelines.
+
 ## Tech Stack
 
 - **Language**: Python with uv package manager


### PR DESCRIPTION
## Summary
- Add `make test-canary` target that mimics CI's quick validation tests
- Add `make check-canary` for combined fast checks + canary tests
- Document new testing workflow in README

## Motivation
Developers need a way to quickly validate changes locally before pushing, matching what CI does with its canary tests. This reduces iteration time and catches obvious issues early.

## Changes
- **Makefile**: Added `test-canary` and `check-canary` targets
- **README.md**: Added "Development & Testing" section documenting the new workflow
- **.gitignore**: Added junit-canary.xml to ignored files

## Testing Approach
The canary tests:
- Skip integration, slow, and LLM tests for speed
- Fail fast on first error with 10 failure limit
- Set 15-second timeout per test
- Complete in under 30 seconds
- Output results to junit-canary.xml for analysis

## Usage
```bash
# Quick validation before push (recommended)
make check-canary

# Just run canary tests
make test-canary
```

## Context
This addresses the P3 developer experience priority to "mimic CI's canary test run locally so developers can quickly validate changes before pushing."

🤖 Generated with [Claude Code](https://claude.ai/code)