### PR TITLE
fix(search): convert base classes to proper abstract base classes

### DIFF
--- a/src/scriptrag/search/filters.py
+++ b/src/scriptrag/search/filters.py
@@ -1,5 +1,7 @@
 """Search filtering logic for different content types."""
 
+from abc import ABC, abstractmethod
+
 from scriptrag.search.models import (
     BibleSearchResult,
     SearchQuery,
@@ -44,9 +46,10 @@ class SearchFilterChain:
         return filtered
 
 
-class SearchFilter:
+class SearchFilter(ABC):
     """Base class for search filters."""
 
+    @abstractmethod
     def filter(
         self,
         results: list[SearchResult],
@@ -61,7 +64,6 @@ class SearchFilter:
         Returns:
             Filtered results
         """
-        raise NotImplementedError
 
 
 class CharacterFilter(SearchFilter):

--- a/src/scriptrag/search/rankers.py
+++ b/src/scriptrag/search/rankers.py
@@ -1,13 +1,15 @@
 """Result ranking and scoring for search results."""
 
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 
 from scriptrag.search.models import BibleSearchResult, SearchQuery, SearchResult
 
 
-class SearchRanker:
+class SearchRanker(ABC):
     """Base class for search result ranking."""
 
+    @abstractmethod
     def rank(
         self, results: list[SearchResult], query: SearchQuery
     ) -> list[SearchResult]:
@@ -20,7 +22,6 @@ class SearchRanker:
         Returns:
             Ranked results
         """
-        raise NotImplementedError
 
 
 class RelevanceRanker(SearchRanker):

--- a/tests/unit/test_search_filters.py
+++ b/tests/unit/test_search_filters.py
@@ -18,11 +18,48 @@ from scriptrag.search.models import BibleSearchResult, SearchQuery, SearchResult
 class TestSearchFilter:
     """Test base SearchFilter class."""
 
-    def test_filter_not_implemented(self) -> None:
-        """Test that base filter raises NotImplementedError."""
-        base_filter = SearchFilter()
-        with pytest.raises(NotImplementedError):
-            base_filter.filter([], SearchQuery(raw_query="test"))
+    def test_cannot_instantiate_abstract_class(self) -> None:
+        """Test that base filter cannot be instantiated directly."""
+        with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+            SearchFilter()
+
+    def test_concrete_subclass_must_implement_filter(self) -> None:
+        """Test that concrete subclasses must implement filter method."""
+
+        # Create a class that doesn't implement filter
+        class IncompleteFilter(SearchFilter):
+            pass
+
+        with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+            IncompleteFilter()
+
+    def test_proper_subclass_can_be_instantiated(self) -> None:
+        """Test that a proper implementation can be instantiated."""
+
+        # Create a complete implementation
+        class CompleteFilter(SearchFilter):
+            def filter(
+                self, results: list[SearchResult], query: SearchQuery
+            ) -> list[SearchResult]:
+                return results
+
+        # Should not raise an error
+        filter_instance = CompleteFilter()
+        test_results = [
+            SearchResult(
+                script_id=1,
+                script_title="Test",
+                script_author="Author",
+                scene_id=1,
+                scene_number=1,
+                scene_heading="INT. OFFICE - DAY",
+                scene_location="INT. OFFICE",
+                scene_time="DAY",
+                scene_content="Content",
+            )
+        ]
+        query = SearchQuery(raw_query="test")
+        assert filter_instance.filter(test_results, query) == test_results
 
 
 class TestSearchFilterChain:

--- a/tests/unit/test_search_rankers.py
+++ b/tests/unit/test_search_rankers.py
@@ -18,11 +18,49 @@ from scriptrag.search.rankers import (
 class TestSearchRanker:
     """Test base SearchRanker class."""
 
-    def test_rank_not_implemented(self) -> None:
-        """Test that base ranker raises NotImplementedError."""
-        base_ranker = SearchRanker()
-        with pytest.raises(NotImplementedError):
-            base_ranker.rank([], SearchQuery(raw_query="test"))
+    def test_cannot_instantiate_abstract_class(self) -> None:
+        """Test that base ranker cannot be instantiated directly."""
+        with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+            SearchRanker()
+
+    def test_concrete_subclass_must_implement_rank(self) -> None:
+        """Test that concrete subclasses must implement rank method."""
+
+        # Create a class that doesn't implement rank
+        class IncompleteRanker(SearchRanker):
+            pass
+
+        with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+            IncompleteRanker()
+
+    def test_proper_subclass_can_be_instantiated(self) -> None:
+        """Test that a proper implementation can be instantiated."""
+
+        # Create a complete implementation
+        class CompleteRanker(SearchRanker):
+            def rank(
+                self, results: list[SearchResult], query: SearchQuery
+            ) -> list[SearchResult]:
+                return results
+
+        # Should not raise an error
+        ranker = CompleteRanker()
+        test_results = [
+            SearchResult(
+                script_id=1,
+                script_title="Test",
+                script_author="Author",
+                scene_id=1,
+                scene_number=1,
+                scene_heading="INT. OFFICE - DAY",
+                scene_location="INT. OFFICE",
+                scene_time="DAY",
+                scene_content="Content",
+                relevance_score=0.5,
+            )
+        ]
+        query = SearchQuery(raw_query="test")
+        assert ranker.rank(test_results, query) == test_results
 
 
 class TestRelevanceRanker:


### PR DESCRIPTION
## Summary
- Fixed design issue where SearchRanker and SearchFilter base classes used NotImplementedError instead of ABC pattern
- Converts base classes to proper abstract base classes using abc.ABC
- Prevents runtime errors from improper base class instantiation

## Changes
- **SearchRanker**: Now inherits from ABC with @abstractmethod for rank()
- **SearchFilter**: Now inherits from ABC with @abstractmethod for filter()
- **Tests**: Updated to verify abstract class behavior and proper subclass implementation

## Benefits
- ✅ Type safety at instantiation time
- ✅ Better IDE support for required method implementation
- ✅ Enforces interface contracts at language level
- ✅ Prevents accidental base class instantiation

## Test Coverage
- `src/scriptrag/search/rankers.py`: 97.42% coverage
- `src/scriptrag/search/filters.py`: 98.84% coverage
- All 64 tests pass with comprehensive verification of abstract class behavior

## CI Status
- ✅ Linting (Ruff)
- ✅ Type checking (MyPy)  
- ✅ Security checks (Bandit)
- ✅ Docstring coverage (99.7%)
- ✅ SQL linting (SQLFluff)
- ✅ Unit tests

This improves code safety by enforcing interface contracts at the language level rather than relying on runtime exceptions.

🤖 Generated with [Claude Code](https://claude.ai/code)