### PR TITLE
fix(ci): Disable LLM tests in CI to prevent GitHub Models API rate limit failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
           SCRIPTRAG_LLM_API_KEY: ${{ secrets.SCRIPTRAG_LLM_API_KEY }}
           SCRIPTRAG_LLM_DEFAULT_MODEL: ${{ secrets.SCRIPTRAG_LLM_DEFAULT_MODEL || 'default' }}
           SCRIPTRAG_ENVIRONMENT: testing
+          SCRIPTRAG_TEST_LLMS: ""  # Disable LLM tests in CI to prevent rate limit failures
 
       - name: Surface canary test results
         uses: pmeier/pytest-results-action@main
@@ -298,6 +299,7 @@ jobs:
           SCRIPTRAG_LLM_API_KEY: ${{ secrets.SCRIPTRAG_LLM_API_KEY }}
           SCRIPTRAG_LLM_DEFAULT_MODEL: ${{ secrets.SCRIPTRAG_LLM_DEFAULT_MODEL || 'default' }}
           SCRIPTRAG_ENVIRONMENT: testing
+          SCRIPTRAG_TEST_LLMS: ""  # Disable LLM tests in CI to prevent rate limit failures
 
       - name: Surface failing tests
         uses: pmeier/pytest-results-action@main
@@ -445,6 +447,7 @@ jobs:
           SCRIPTRAG_LLM_API_KEY: ${{ secrets.SCRIPTRAG_LLM_API_KEY }}
           SCRIPTRAG_LLM_DEFAULT_MODEL: ${{ secrets.SCRIPTRAG_LLM_DEFAULT_MODEL || 'default' }}
           SCRIPTRAG_ENVIRONMENT: testing
+          SCRIPTRAG_TEST_LLMS: ""  # Explicitly disable LLM tests to prevent rate limit failures
 
       - name: Surface failing integration tests
         uses: pmeier/pytest-results-action@main


### PR DESCRIPTION
## Summary
- Fixes CI failures caused by GitHub Models API rate limiting (50 requests/day limit)
- Adds `SCRIPTRAG_TEST_LLMS: ""` environment variable to disable LLM tests in CI jobs
- Resolves the integration test failures affecting PR #396 and other PRs

## Changes
- **Canary Test job**: Added `SCRIPTRAG_TEST_LLMS: ""` to skip LLM tests
- **Test Matrix job**: Added `SCRIPTRAG_TEST_LLMS: ""` to skip LLM tests  
- **Integration job**: Added `SCRIPTRAG_TEST_LLMS: ""` to explicitly disable LLM tests

## Technical Details
The `conftest.py` already has logic to skip tests marked with `@pytest.mark.requires_llm` when `SCRIPTRAG_TEST_LLMS` is not set, but the CI jobs weren't explicitly setting this variable. This caused integration tests to attempt LLM calls and hit the GitHub Models API daily rate limit of 50 requests.

By explicitly setting `SCRIPTRAG_TEST_LLMS: ""` (empty string), we ensure LLM tests are consistently skipped in CI while still allowing developers to run them locally when needed.

## Test Plan
- [x] CI workflow file updated with environment variables
- [ ] Push triggers CI to validate the fix
- [ ] Integration tests should pass by skipping LLM-dependent tests
- [ ] Other test jobs (canary, matrix) should continue passing

🤖 Generated with [Claude Code](https://claude.ai/code)