### PR TITLE
refactor(bible): centralize scene/character keyword heuristics

### DIFF
--- a/src/scriptrag/api/bible/character_bible.py
+++ b/src/scriptrag/api/bible/character_bible.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from scriptrag.api.bible.utils import LLMResponseParser
+from scriptrag.api.bible.utils import CHARACTER_KEYWORDS, LLMResponseParser
 from scriptrag.config import get_logger
 from scriptrag.llm import LLMClient
 from scriptrag.parser.bible_parser import BibleParser, ParsedBible
@@ -108,21 +108,11 @@ class BibleCharacterExtractor:
             a list containing "Main Characters\n\nJane Smith is the detective..."
         """
         character_chunks = []
-        character_keywords = [
-            "character",
-            "protagonist",
-            "antagonist",
-            "cast",
-            "role",
-            "player",
-            "person",
-            "name",
-        ]
 
         for chunk in parsed_bible.chunks:
             # Check if heading suggests character content
             heading_lower = (chunk.heading or "").lower()
-            if any(keyword in heading_lower for keyword in character_keywords):
+            if any(keyword in heading_lower for keyword in CHARACTER_KEYWORDS):
                 # Include heading with content for context
                 chunk_text = (
                     f"{chunk.heading}\n{chunk.content}"
@@ -134,7 +124,7 @@ class BibleCharacterExtractor:
 
             # Check if content has character mentions (quick heuristic)
             content_lower = chunk.content.lower()
-            if any(keyword in content_lower for keyword in character_keywords[:4]):
+            if any(keyword in content_lower for keyword in CHARACTER_KEYWORDS[:4]):
                 # Include heading with content for context
                 chunk_text = (
                     f"{chunk.heading}\n{chunk.content}"

--- a/src/scriptrag/api/bible/scene_bible.py
+++ b/src/scriptrag/api/bible/scene_bible.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from scriptrag.api.bible.utils import LLMResponseParser
+from scriptrag.api.bible.utils import SCENE_KEYWORDS, LLMResponseParser
 from scriptrag.config import get_logger
 from scriptrag.llm import LLMClient
 from scriptrag.parser.bible_parser import BibleParser, ParsedBible
@@ -79,21 +79,11 @@ class SceneBibleExtractor:
             Returns empty list if no scene-related chunks are found.
         """
         scene_chunks = []
-        scene_keywords = [
-            "scene",
-            "location",
-            "setting",
-            "place",
-            "environment",
-            "interior",
-            "exterior",
-            "stage",
-        ]
 
         for chunk in parsed_bible.chunks:
             # Check if heading suggests scene content
             heading_lower = (chunk.heading or "").lower()
-            if any(keyword in heading_lower for keyword in scene_keywords):
+            if any(keyword in heading_lower for keyword in SCENE_KEYWORDS):
                 # Include heading with content for context
                 chunk_text = (
                     f"{chunk.heading}\n{chunk.content}"
@@ -105,7 +95,7 @@ class SceneBibleExtractor:
 
             # Check if content has scene mentions (quick heuristic)
             content_lower = chunk.content.lower()
-            if any(keyword in content_lower for keyword in scene_keywords[:4]):
+            if any(keyword in content_lower for keyword in SCENE_KEYWORDS[:4]):
                 # Include heading with content for context
                 chunk_text = (
                     f"{chunk.heading}\n{chunk.content}"


### PR DESCRIPTION
This PR addresses feedback from PR #400 by reducing duplication in the Bible extractors.

- Replace in-module keyword lists with shared constants from utils (CHARACTER_KEYWORDS, SCENE_KEYWORDS).
- Both extractors already use the shared LLMResponseParser.extract_json_array for JSON parsing; this keeps all heuristics centralized alongside that utility.

Why:
- Single source of truth for keyword heuristics
- Easier maintenance and tuning across both extractors
- Complements the prior JSON parsing consolidation

Diagnostics & Tests:
- Ran targeted format and lint on changed files (ruff, mypy) — all clean.
- Executed a focused test subset excluding slow/integration/LLM: uv run pytest -m 'not integration and not slow and not requires_llm' -k 'bible or character or scene' — passing for affected areas.
- Full CI should validate broader coverage; please review CI checks for confirmation.

Notes:
- No functional changes to extraction logic; only removal of duplicated keyword arrays.

Refs: PR #400