### PR TITLE
Add performance safeguards to JSON extraction in LLMResponseParser

### DIFF
--- a/src/scriptrag/api/bible/utils.py
+++ b/src/scriptrag/api/bible/utils.py
@@ -83,19 +83,49 @@ class LLMResponseParser:
         # parse them. This handles nested structures better than the previous regex
         # approach
 
+        # Performance safeguards for pathological inputs
+        max_nesting_depth = 100
+        max_search_distance = 50000
+        max_parse_attempts = 20
+
         # Find all bracket pairs that could be JSON arrays
         potential_arrays = []
+        parse_attempts = 0
 
         # Look for array start positions
         start_positions = [m.start() for m in re.finditer(r"\[", response)]
 
         for start in start_positions:
+            # Early termination if too many failed parse attempts
+            if parse_attempts >= max_parse_attempts:
+                logger.warning(
+                    f"Reached max parse attempts ({max_parse_attempts}) "
+                    "during JSON extraction"
+                )
+                break
+            parse_attempts += 1
+
             # Find the matching closing bracket by counting nesting levels
             bracket_count = 0
             in_string = False
             escape_next = False
 
             for i, char in enumerate(response[start:], start):
+                # Check performance limits
+                if bracket_count > max_nesting_depth:
+                    logger.warning(
+                        f"Max nesting depth ({max_nesting_depth}) exceeded "
+                        f"at position {i}"
+                    )
+                    break
+
+                if i - start > max_search_distance:
+                    logger.warning(
+                        f"Max search distance ({max_search_distance}) exceeded "
+                        f"from start position {start}"
+                    )
+                    break
+
                 if escape_next:
                     escape_next = False
                     continue


### PR DESCRIPTION
## Summary
- Introduces performance safeguards to the JSON extraction logic in `LLMResponseParser` to handle pathological inputs more efficiently
- Adds limits on nesting depth, search distance, and parse attempts to prevent excessive processing and potential hangs
- Logs warnings when these limits are exceeded for better observability

## Changes

### Core Functionality
- Added constants for `max_nesting_depth`, `max_search_distance`, and `max_parse_attempts` to control parsing behavior
- Modified the bracket matching loop to:
  - Break early if maximum nesting depth is exceeded
  - Break early if the search distance from the start bracket exceeds the limit
  - Limit the total number of parse attempts to avoid excessive retries
- Added logging warnings when any of these limits are hit to aid debugging and monitoring

## Test plan
- [ ] Verify that JSON extraction still works correctly for valid inputs
- [ ] Test with deeply nested JSON to confirm max nesting depth enforcement
- [ ] Test with very large inputs to confirm max search distance enforcement
- [ ] Confirm that parse attempts limit prevents excessive processing on malformed inputs
- [ ] Check logs for appropriate warnings when limits are exceeded

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/0d712f49-40c3-4e3a-97d3-3bd87dd7750d