### PR TITLE
Remove deprecated settings parameter from QueryEngine

### DIFF
--- a/src/scriptrag/agents/context_query.py
+++ b/src/scriptrag/agents/context_query.py
@@ -173,7 +173,7 @@ class ContextQueryExecutor:
             settings = get_settings()
 
         self.settings = settings
-        self.engine = QueryEngine(settings)
+        self.engine = QueryEngine()
 
     async def execute(
         self,

--- a/src/scriptrag/query/engine.py
+++ b/src/scriptrag/query/engine.py
@@ -14,15 +14,9 @@ logger = get_logger(__name__)
 class QueryEngine:
     """Execute SQL queries with parameter binding."""
 
-    def __init__(self, settings: ScriptRAGSettings | None = None) -> None:
-        """Initialize query engine.
-
-        Args:
-            settings: Configuration settings (deprecated, use get_settings())
-        """
-        # Store settings but prefer get_settings() for runtime configuration
-        # This ensures tests with environment variable changes work correctly
-        self._initial_settings = settings
+    def __init__(self) -> None:
+        """Initialize query engine."""
+        pass
 
     @property
     def settings(self) -> ScriptRAGSettings:
@@ -31,11 +25,6 @@ class QueryEngine:
         This ensures tests that modify environment variables and call reset_settings()
         will see the updated configuration.
         """
-        if self._initial_settings is not None:
-            # Use initial settings if provided (for backward compatibility)
-            return self._initial_settings
-
-        # Use module-level import to avoid circular import issues
         return get_settings()
 
     @property

--- a/tests/unit/test_query_engine_trailing_semicolon.py
+++ b/tests/unit/test_query_engine_trailing_semicolon.py
@@ -9,7 +9,7 @@ from scriptrag.query.spec import ParamSpec, QuerySpec
 
 
 @pytest.mark.unit
-def test_query_engine_strips_trailing_semicolon_and_wraps(tmp_path: Path):
+def test_query_engine_strips_trailing_semicolon_and_wraps(tmp_path: Path, monkeypatch):
     """Ensure trailing semicolons are stripped before wrapping for LIMIT/OFFSET.
 
     This covers the logic that normalizes SQL (removes trailing ';') so that
@@ -25,7 +25,8 @@ def test_query_engine_strips_trailing_semicolon_and_wraps(tmp_path: Path):
 
     # Engine configured to open the file in read-only mode
     settings = ScriptRAGSettings(database_path=db_path)
-    engine = QueryEngine(settings)
+    monkeypatch.setattr("scriptrag.query.engine.get_settings", lambda: settings)
+    engine = QueryEngine()
 
     # Note the trailing semicolon in SQL; engine should strip it and wrap
     spec = QuerySpec(


### PR DESCRIPTION
## Summary
- Removed the deprecated `settings` parameter from the `QueryEngine` constructor.
- Updated `ContextQueryExecutor` and tests to instantiate `QueryEngine` without passing settings.
- Refactored tests to use `monkeypatch` to mock `get_settings()` for providing settings dynamically.

## Changes

### Core Functionality
- **QueryEngine**: Simplified constructor by removing the optional `settings` parameter and related logic.
- **ContextQueryExecutor**: Updated to create `QueryEngine` without settings argument.

### Tests
- Modified multiple test cases to use `monkeypatch` for mocking `get_settings()` instead of passing settings directly.
- Ensured all tests create `QueryEngine` instances without parameters, relying on mocked `get_settings()`.
- Updated tests to maintain coverage and handle environment variable changes correctly.

## Test plan
- [x] Run all existing unit tests to verify no regressions.
- [x] Confirm tests pass with the new `QueryEngine` constructor.
- [x] Validate that settings are correctly injected via `get_settings()` mock in tests.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f4df4d79-3340-4ff4-bc85-dc810acd6c01