### PR TITLE
Add explicit Any type annotation to CompositeValidator result

### DIFF
--- a/src/scriptrag/cli/validators/base.py
+++ b/src/scriptrag/cli/validators/base.py
@@ -134,7 +134,7 @@ class CompositeValidator(Validator[T]):
         Raises:
             ValidationError: If any validator fails
         """
-        result = value
+        result: Any = value
         for validator in self.validators:
             result = validator.validate(result)
         return result  # type: ignore[no-any-return]


### PR DESCRIPTION
## Summary
- Adds an explicit `Any` type annotation to the `result` variable in `CompositeValidator.validate` method
- Improves type clarity and resolves type checking issues related to the dynamic nature of the validation chain

## Changes

### Code Update
- Modified `CompositeValidator.validate` method in `src/scriptrag/cli/validators/base.py`:
  - Changed `result = value` to `result: Any = value` to explicitly declare the type
  - Retained the existing logic of iterating over validators and updating `result`
  - Kept the `# type: ignore[no-any-return]` comment on the return statement to suppress type warnings

## Test plan
- Existing tests for `CompositeValidator` should continue to pass
- No functional behavior changes, only type annotation improvements

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/349386d7-f7ee-4f28-b8e9-079f23d95f1c