### PR TITLE
Refine type ignore comments in Bible character validator tests

### DIFF
--- a/tests/unit/test_bible_validators.py
+++ b/tests/unit/test_bible_validators.py
@@ -41,19 +41,19 @@ class TestBibleValidatorCharacter:
     def test_validate_character_invalid_aliases_type(self) -> None:
         """Test character with non-list aliases is invalid."""
         character = BibleCharacter(canonical="JOHN", aliases=[])
-        character.aliases = "not a list"  # type: ignore
+        character.aliases = "not a list"  # type: ignore[assignment]
         assert BibleValidator.validate_character(character) is False
 
     def test_validate_character_invalid_tags_type(self) -> None:
         """Test character with non-list tags is invalid."""
         character = BibleCharacter(canonical="JOHN", aliases=[])
-        character.tags = "not a list"  # type: ignore
+        character.tags = "not a list"  # type: ignore[assignment]
         assert BibleValidator.validate_character(character) is False
 
     def test_validate_character_invalid_notes_type(self) -> None:
         """Test character with non-string notes is invalid."""
         character = BibleCharacter(canonical="JOHN", aliases=[])
-        character.notes = 123  # type: ignore
+        character.notes = 123  # type: ignore[assignment]
         assert BibleValidator.validate_character(character) is False
 
     def test_validate_character_none_tags_valid(self) -> None:


### PR DESCRIPTION
## Summary
- Updated type ignore comments in `test_bible_validators.py` to specify assignment context
- Improved code clarity and adherence to type checking conventions in tests

## Changes

### Tests
- Modified type ignore comments from generic `# type: ignore` to `# type: ignore[assignment]` for:
  - `aliases` attribute
  - `tags` attribute
  - `notes` attribute
- Ensured that invalid type assignments in `TestBibleValidatorCharacter` tests are explicitly marked for assignment ignoring

## Test plan
- Existing unit tests for Bible character validation continue to pass
- No functional changes, only comment refinements for type checking
- Verified that tests correctly identify invalid types for character attributes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b4e818dc-b530-46ea-b0fe-9bc2d6981447