### PR TITLE
Fix invalid unicode escape test case in Bible extraction tests

### DIFF
--- a/tests/unit/test_bible_extraction_additional_coverage.py
+++ b/tests/unit/test_bible_extraction_additional_coverage.py
@@ -273,8 +273,8 @@ Camera angles and lighting setup.
             '[{"canonical": "JA"NE", "aliases": ["J"]}]',
             # Missing quotes
             '[{canonical: "JANE", aliases: ["J"]}]',
-            # Invalid unicode escape
-            '[{"canonical": "JANE\\uXXXX", "aliases": ["J"]}]',
+            # Invalid unicode escape (malformed hex digits)
+            r'[{"canonical": "JANE\uGGGG", "aliases": ["J"]}]',
         ]
 
         for invalid_response in test_cases:


### PR DESCRIPTION
## Summary
- Corrects the invalid unicode escape sequence in a test case within `test_bible_extraction_additional_coverage.py`
- Changes the malformed unicode escape from `\uXXXX` to a raw string with `\uGGGG` to better represent malformed hex digits

## Changes

### Tests
- Updated the invalid unicode escape test case comment to clarify the nature of the error (malformed hex digits)
- Changed the test string to use a raw string literal to avoid Python interpreting the invalid escape sequence

## Test plan
- Run the unit tests in `tests/unit/test_bible_extraction_additional_coverage.py` to ensure the test case behaves as expected
- Verify no syntax or runtime errors occur due to the unicode escape sequence in the test

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a20e78a0-830c-40ad-9dcc-47d84b4562b7