### PR TITLE
Add verbose logging option and set default log level to WARNING

### DIFF
--- a/src/scriptrag/cli/main.py
+++ b/src/scriptrag/cli/main.py
@@ -139,17 +139,51 @@ def main_callback(
             envvar="SCRIPTRAG_CONFIG",
         ),
     ] = None,
+    verbose: Annotated[
+        bool,
+        typer.Option("--verbose", "-v", help="Enable verbose (INFO level) logging"),
+    ] = False,
     debug: Annotated[
         bool,
         typer.Option("--debug", help="Enable debug logging", envvar="SCRIPTRAG_DEBUG"),
     ] = False,
 ) -> None:
     """Configure global options."""
-    if debug:
-        import logging
+    from scriptrag.config import clear_settings_cache, get_settings, set_settings
 
-        logging.basicConfig(level=logging.DEBUG)
-        logger.debug("Debug mode enabled")
+    # Handle logging level overrides
+    if debug or verbose:
+        # Clear any cached settings first
+        clear_settings_cache()
+
+        # Get current settings
+        current_settings = get_settings()
+
+        # Override log level based on flags
+        if debug:
+            new_log_level = "DEBUG"
+        elif verbose:
+            new_log_level = "INFO"
+        else:
+            new_log_level = current_settings.log_level
+
+        # Create new settings with overridden log level
+        settings_dict = current_settings.model_dump()
+        settings_dict["log_level"] = new_log_level
+
+        from scriptrag.config.settings import ScriptRAGSettings
+
+        new_settings = ScriptRAGSettings(**settings_dict)
+
+        # Set the new settings globally
+        set_settings(new_settings)
+
+        # Re-configure logging with new level
+        from scriptrag.config import configure_logging
+
+        configure_logging(new_settings)
+
+        logger.debug("Debug mode enabled" if debug else "Verbose mode enabled")
 
     if config:
         # Load configuration from file

--- a/src/scriptrag/common/file_source.py
+++ b/src/scriptrag/common/file_source.py
@@ -183,7 +183,7 @@ class FileSourceResolver:
             except Exception as e:
                 logger.error(f"Error scanning directory {directory}: {e}")
 
-        logger.info(
+        logger.debug(
             f"Discovered {len(discovered_files)} {self.file_type} files across "
             f"{len(directories)} directories"
         )

--- a/src/scriptrag/config/settings.py
+++ b/src/scriptrag/config/settings.py
@@ -108,7 +108,7 @@ class ScriptRAGSettings(BaseSettings):
 
     # Logging settings
     log_level: str = Field(
-        default="INFO",
+        default="WARNING",
         description="Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
         pattern="^(?i)(DEBUG|INFO|WARNING|ERROR|CRITICAL)$",
     )

--- a/src/scriptrag/config/template.py
+++ b/src/scriptrag/config/template.py
@@ -44,8 +44,10 @@ def generate_config_template() -> str:
         "debug": False,
         "# Enable debug mode (default: false)": None,
         "\n# Logging Configuration": None,
-        "log_level": "INFO",
-        "# Logging level: DEBUG, INFO, WARNING, ERROR, CRITICAL (default: INFO)": None,
+        "log_level": "WARNING",
+        "# Logging level: DEBUG, INFO, WARNING, ERROR, CRITICAL (default: WARNING)": (
+            None
+        ),
         "log_format": "console",
         "# Log output format: console, json, structured (default: console)": None,
         "# log_file: /path/to/logfile.log": None,

--- a/src/scriptrag/query/loader.py
+++ b/src/scriptrag/query/loader.py
@@ -109,7 +109,7 @@ class QueryLoader:
             if query_dir.exists() and query_dir.is_dir():
                 # Only use the environment-specified directory
                 sql_files = list(query_dir.glob("*.sql"))
-                logger.info(f"Found {len(sql_files)} SQL files in {query_dir}")
+                logger.debug(f"Found {len(sql_files)} SQL files in {query_dir}")
             else:
                 logger.warning(
                     f"SCRIPTRAG_QUERY_DIR set but path doesn't exist: {env_dir}"
@@ -120,7 +120,7 @@ class QueryLoader:
             # Use only that directory
             if self._query_dir.exists() and self._query_dir.is_dir():
                 sql_files = list(self._query_dir.glob("*.sql"))
-                logger.info(f"Found {len(sql_files)} SQL files in {self._query_dir}")
+                logger.debug(f"Found {len(sql_files)} SQL files in {self._query_dir}")
             else:
                 # Query directory doesn't exist, return empty list
                 logger.warning(f"Query directory doesn't exist: {self._query_dir}")
@@ -128,7 +128,7 @@ class QueryLoader:
         else:
             # Discover all SQL files using the resolver from multiple sources
             sql_files = self._resolver.discover_files(pattern="*.sql")
-            logger.info(f"Found {len(sql_files)} SQL files across search directories")
+            logger.debug(f"Found {len(sql_files)} SQL files across search directories")
 
         for sql_file in sql_files:
             try:
@@ -146,7 +146,7 @@ class QueryLoader:
 
         # Update cache
         self._cache = queries
-        logger.info(f"Loaded {len(queries)} queries")
+        logger.debug(f"Loaded {len(queries)} queries")
 
         return queries
 

--- a/tests/unit/test_config_settings_complete.py
+++ b/tests/unit/test_config_settings_complete.py
@@ -91,7 +91,7 @@ class TestScriptRAGSettingsInitialization:
         assert settings.debug is False
 
         # Logging defaults
-        assert settings.log_level == "INFO"
+        assert settings.log_level == "WARNING"
         assert settings.log_format == "console"
         assert settings.log_file is None
         assert settings.log_file_rotation == "1 day"

--- a/tests/unit/test_settings_integration.py
+++ b/tests/unit/test_settings_integration.py
@@ -82,7 +82,7 @@ class TestSettingsIntegration:
         settings = ScriptRAGSettings(_env_file=None)
 
         # Check logging settings
-        assert settings.log_level == "INFO"
+        assert settings.log_level == "WARNING"
         assert settings.log_format == "console"
         assert settings.log_file is None
         assert settings.log_file_rotation == "1 day"


### PR DESCRIPTION
## Summary
- Introduces a `--verbose` (`-v`) CLI option to enable INFO level logging
- Changes default logging level from INFO to WARNING in settings and config templates
- Updates logging configuration to respect debug and verbose flags
- Converts various info-level log messages to debug-level for cleaner output

## Changes

### CLI and Logging
- Added `verbose` option to CLI main callback to enable INFO logging
- Adjusted logging setup to clear settings cache and reconfigure logging based on debug/verbose flags
- Debug flag sets log level to DEBUG, verbose flag sets it to INFO
- Log messages indicating mode enabled (debug or verbose) added

### Configuration
- Default `log_level` changed from "INFO" to "WARNING" in `ScriptRAGSettings`
- Updated config template to reflect new default log level WARNING

### Logging Messages
- Downgraded several `logger.info` calls to `logger.debug` in file discovery and query loading to reduce noise

### Tests
- Updated tests to expect default log level WARNING instead of INFO

## Test plan
- Verified CLI flags `--debug` and `--verbose` correctly set logging levels
- Confirmed default log level is WARNING when no flags are set
- Ran unit tests to ensure logging defaults and integration tests pass with new default
- Observed debug and verbose logs appear appropriately when flags are used

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/fb5963ab-f47c-41f9-b45b-bd89fab45d37