### PR TITLE
Fix CLI default log level and improve logging configuration

### DIFF
--- a/src/scriptrag/cli/main.py
+++ b/src/scriptrag/cli/main.py
@@ -139,17 +139,54 @@ def main_callback(
             envvar="SCRIPTRAG_CONFIG",
         ),
     ] = None,
+    verbose: Annotated[
+        bool,
+        typer.Option("--verbose", "-v", help="Enable verbose logging (INFO level)"),
+    ] = False,
     debug: Annotated[
         bool,
         typer.Option("--debug", help="Enable debug logging", envvar="SCRIPTRAG_DEBUG"),
     ] = False,
 ) -> None:
     """Configure global options."""
+    # Set logging level based on flags
     if debug:
-        import logging
+        import os
 
-        logging.basicConfig(level=logging.DEBUG)
+        # Set environment variable for debug mode
+        os.environ["SCRIPTRAG_LOG_LEVEL"] = "DEBUG"
+        os.environ["SCRIPTRAG_DEBUG"] = "true"
+
+        # Force reconfiguration of logging
+        from scriptrag.config import (
+            clear_settings_cache,
+            configure_logging,
+            get_settings,
+        )
+
+        clear_settings_cache()
+        settings = get_settings()
+        configure_logging(settings)
+
         logger.debug("Debug mode enabled")
+    elif verbose:
+        import os
+
+        # Set environment variable for verbose mode
+        os.environ["SCRIPTRAG_LOG_LEVEL"] = "INFO"
+
+        # Force reconfiguration of logging
+        from scriptrag.config import (
+            clear_settings_cache,
+            configure_logging,
+            get_settings,
+        )
+
+        clear_settings_cache()
+        settings = get_settings()
+        configure_logging(settings)
+
+        logger.info("Verbose mode enabled")
 
     if config:
         # Load configuration from file

--- a/src/scriptrag/common/file_source.py
+++ b/src/scriptrag/common/file_source.py
@@ -183,7 +183,7 @@ class FileSourceResolver:
             except Exception as e:
                 logger.error(f"Error scanning directory {directory}: {e}")
 
-        logger.info(
+        logger.debug(
             f"Discovered {len(discovered_files)} {self.file_type} files across "
             f"{len(directories)} directories"
         )

--- a/src/scriptrag/config/settings.py
+++ b/src/scriptrag/config/settings.py
@@ -108,7 +108,7 @@ class ScriptRAGSettings(BaseSettings):
 
     # Logging settings
     log_level: str = Field(
-        default="INFO",
+        default="WARNING",
         description="Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
         pattern="^(?i)(DEBUG|INFO|WARNING|ERROR|CRITICAL)$",
     )

--- a/src/scriptrag/query/loader.py
+++ b/src/scriptrag/query/loader.py
@@ -53,7 +53,7 @@ class QueryLoader:
         if env_dir:
             env_path = Path(env_dir)
             if env_path.exists() and env_path.is_dir():
-                logger.info(f"Using query directory from env: {env_path}")
+                logger.debug(f"Using query directory from env: {env_path}")
                 return env_path
             logger.warning(f"SCRIPTRAG_QUERY_DIR set but path doesn't exist: {env_dir}")
             # Fall back to resolver/default behavior
@@ -109,7 +109,7 @@ class QueryLoader:
             if query_dir.exists() and query_dir.is_dir():
                 # Only use the environment-specified directory
                 sql_files = list(query_dir.glob("*.sql"))
-                logger.info(f"Found {len(sql_files)} SQL files in {query_dir}")
+                logger.debug(f"Found {len(sql_files)} SQL files in {query_dir}")
             else:
                 logger.warning(
                     f"SCRIPTRAG_QUERY_DIR set but path doesn't exist: {env_dir}"
@@ -120,7 +120,7 @@ class QueryLoader:
             # Use only that directory
             if self._query_dir.exists() and self._query_dir.is_dir():
                 sql_files = list(self._query_dir.glob("*.sql"))
-                logger.info(f"Found {len(sql_files)} SQL files in {self._query_dir}")
+                logger.debug(f"Found {len(sql_files)} SQL files in {self._query_dir}")
             else:
                 # Query directory doesn't exist, return empty list
                 logger.warning(f"Query directory doesn't exist: {self._query_dir}")
@@ -128,7 +128,7 @@ class QueryLoader:
         else:
             # Discover all SQL files using the resolver from multiple sources
             sql_files = self._resolver.discover_files(pattern="*.sql")
-            logger.info(f"Found {len(sql_files)} SQL files across search directories")
+            logger.debug(f"Found {len(sql_files)} SQL files across search directories")
 
         for sql_file in sql_files:
             try:
@@ -146,7 +146,7 @@ class QueryLoader:
 
         # Update cache
         self._cache = queries
-        logger.info(f"Loaded {len(queries)} queries")
+        logger.debug(f"Loaded {len(queries)} queries")
 
         return queries
 

--- a/tests/unit/test_config_settings_complete.py
+++ b/tests/unit/test_config_settings_complete.py
@@ -91,7 +91,7 @@ class TestScriptRAGSettingsInitialization:
         assert settings.debug is False
 
         # Logging defaults
-        assert settings.log_level == "INFO"
+        assert settings.log_level == "WARNING"
         assert settings.log_format == "console"
         assert settings.log_file is None
         assert settings.log_file_rotation == "1 day"

--- a/tests/unit/test_settings_integration.py
+++ b/tests/unit/test_settings_integration.py
@@ -82,7 +82,7 @@ class TestSettingsIntegration:
         settings = ScriptRAGSettings(_env_file=None)
 
         # Check logging settings
-        assert settings.log_level == "INFO"
+        assert settings.log_level == "WARNING"
         assert settings.log_format == "console"
         assert settings.log_file is None
         assert settings.log_file_rotation == "1 day"


### PR DESCRIPTION
## Summary
- Changed default logging level from INFO to WARNING for better default behavior
- Added `--verbose` (`-v`) CLI option to enable INFO level logging
- Improved logging configuration to dynamically update log level based on CLI flags
- Changed various info-level log messages to debug for less noisy output

## Changes

### CLI
- Added `verbose` option to CLI main callback to enable verbose logging
- Set environment variables and reconfigure logging dynamically when `--debug` or `--verbose` flags are used

### Configuration
- Updated default `log_level` in settings from "INFO" to "WARNING"

### Logging Messages
- Downgraded several info log messages to debug in `FileSourceResolver` and `QueryLoader` to reduce verbosity

### Tests
- Updated tests to expect default log level as WARNING instead of INFO

## Test plan
- [x] Verified CLI `--verbose` flag sets log level to INFO and outputs verbose logs
- [x] Verified CLI `--debug` flag sets log level to DEBUG and outputs debug logs
- [x] Confirmed default log level is WARNING when no flags are set
- [x] Ran unit tests to ensure logging defaults and integration tests pass with updated defaults

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ada8fc0d-0fe6-49a4-ae3d-aa2ed99d243f