### PR TITLE
Fix logging configuration to raise ValueError on invalid log levels

### DIFF
--- a/src/scriptrag/config/logging.py
+++ b/src/scriptrag/config/logging.py
@@ -33,9 +33,21 @@ def configure_logging(settings: ScriptRAGSettings) -> None:
 
     Args:
         settings: Application settings containing logging configuration.
+
+    Raises:
+        ValueError: If the log level is invalid or not found in the logging module.
     """
     # Configure standard library logging
-    log_level = getattr(logging, settings.log_level.upper())
+    # Note: settings.log_level is already normalized to uppercase by the validator
+    try:
+        log_level = getattr(logging, settings.log_level)
+    except AttributeError as e:
+        # Provide a helpful error message if an invalid log level somehow gets through
+        valid_levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+        raise ValueError(
+            f"Invalid log level '{settings.log_level}'. "
+            f"Valid levels are: {', '.join(valid_levels)}"
+        ) from e
 
     # Create formatters based on settings
     if settings.log_format == "json":


### PR DESCRIPTION
## Summary
- Fixes a bug in logging configuration where an invalid log level raised an AttributeError instead of a ValueError
- Adds a helpful error message listing valid log levels when an invalid level is provided
- Removes redundant `.upper()` call on log level since it is already normalized by the validator
- Adds comprehensive unit tests for invalid log levels and log level normalization

## Changes

### Core Functionality
- Updated `configure_logging` to catch `AttributeError` when accessing `logging` levels and raise a `ValueError` with a clear message
- Removed redundant `.upper()` call on `settings.log_level` since it is already uppercase

### Tests
- Added `test_invalid_log_level_raises_value_error` to verify that invalid log levels raise a `ValueError` with a helpful message
- Added `test_log_level_already_uppercase` to confirm that log levels already normalized to uppercase work correctly without redundant transformations

## Test plan
- Run unit tests to ensure all new tests pass
- Verify that providing an invalid log level in settings raises a `ValueError` with the expected message
- Confirm that valid log levels configure logging correctly without errors

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/51f7e9de-f7fa-4823-a463-e91b4bbaae59