### PR TITLE
Fix: Load default analyzer in pull command to enable analysis

### DIFF
--- a/src/scriptrag/cli/commands/pull.py
+++ b/src/scriptrag/cli/commands/pull.py
@@ -113,6 +113,15 @@ def pull_command(
         console.print("\n[cyan]Step 1: Analyzing Fountain files...[/cyan]")
         analyze_cmd = AnalyzeCommand.from_config()
 
+        # Load default analyzers - relationships analyzer for character interactions
+        # Only load if not in dry-run mode (analyzers may require resources)
+        if not dry_run:
+            try:
+                analyze_cmd.load_analyzer("relationships")
+                logger.debug("Loaded relationships analyzer")
+            except Exception as e:
+                logger.warning(f"Failed to load relationships analyzer: {e}")
+
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),


### PR DESCRIPTION
## Summary
- Fixed the `scriptrag pull` command not performing any analysis due to missing analyzer configuration
- Added automatic loading of the relationships analyzer to extract character interactions
- Ensures meaningful analysis is performed by default without requiring manual analyzer specification

## Problem
When running `scriptrag pull`, the command would execute but produce empty analyzer results in the Fountain file metadata:
```json
"analyzers": {}
```

This occurred because the pull command wasn't loading any analyzers by default, making the analysis step essentially a no-op.

## Solution
Modified the pull command to automatically load the relationships analyzer, which extracts character interactions and relationships from screenplays. The analyzer is only loaded when not in dry-run mode to avoid unnecessary resource usage.

## Test Plan
- [x] Ran `scriptrag pull ../eoe/test` and verified analyzer metadata is now populated
- [x] Verified dry-run mode still works without loading analyzers
- [x] Confirmed error handling for analyzer loading failures
- [x] Passed all linting and type checking (`make check-fast`)

🤖 Generated with Claude Code