### PR TITLE
Clarify Official Fountain vs ScriptRAG Episode and Season Metadata Extensions

### DIFF
--- a/docs/fountain-tv-format.md
+++ b/docs/fountain-tv-format.md
@@ -4,11 +4,40 @@
 
 This guide explains how to format Fountain files for TV scripts to ensure ScriptRAG correctly extracts episode and season metadata.
 
-## ScriptRAG-Specific Title Page Extensions
+## Official Fountain vs ScriptRAG Extensions
 
-While the [official Fountain specification](https://fountain.io/) does not define `Episode:` or `Season:` fields, ScriptRAG uses these custom fields to better organize TV series content. This is a **ScriptRAG convention**, not a Fountain standard.
+### Official Fountain Title Page Fields
 
-### Required Format for ScriptRAG (Non-Standard Extensions)
+The [official Fountain specification](https://fountain.io/syntax#section-titlepage) defines these standard title page fields:
+
+- **Title**: The title of the screenplay
+- **Credit**: (e.g., "Written by")
+- **Author** (or Authors): The writer's name(s)
+- **Source**: Based on what existing work, if any
+- **Draft date**: Date of the current draft
+- **Contact**: Contact information
+
+### ScriptRAG-Specific Extensions (Non-Standard)
+
+ScriptRAG adds these **custom fields** specifically for TV series organization:
+
+- **Episode**: Episode number (e.g., `Episode: 1`)
+- **Season**: Season number (e.g., `Season: 1`)
+
+These fields are **NOT recognized by standard Fountain parsers** and are unique to ScriptRAG. They enable better organization and tracking of TV series scripts within the ScriptRAG system.
+
+## Why ScriptRAG Uses These Extensions
+
+ScriptRAG uses Episode and Season fields to:
+
+1. **Uniquely identify TV episodes** in a series
+2. **Track character arcs** across episodes and seasons
+3. **Analyze pacing and structure** within a series context
+4. **Enable filtering and searching** by season/episode
+
+While these fields won't affect how your script renders in other Fountain tools, they provide essential metadata for ScriptRAG's analysis features.
+
+## Required Format for ScriptRAG\n\n### Example with ScriptRAG Extensions
 
 ```fountain
 Title: Show Name - Episode Title
@@ -19,7 +48,7 @@ Episode: 1
 Season: 1
 ```
 
-### ScriptRAG-Specific Requirements
+### Key Requirements for TV Scripts in ScriptRAG
 
 1. **Episode Number**: Must be specified as a separate `Episode:` field (ScriptRAG extension)
 2. **Season Number**: Must be specified as a separate `Season:` field (ScriptRAG extension)
@@ -144,8 +173,29 @@ If you have existing Fountain files in the standard format, you can update them 
 2. Keeping the episode title in the main `Title:` field for clarity
 3. Re-indexing the updated files
 
+## Script Portability Considerations
+
+### Exporting Scripts
+
+When exporting scripts from ScriptRAG for use in other Fountain tools:
+
+- The `Episode:` and `Season:` fields will be preserved in the title page
+- Most Fountain parsers will simply ignore these unknown fields
+- The script will render normally in other tools
+- No script content or formatting is affected
+
+### Importing Scripts
+
+When importing standard Fountain scripts into ScriptRAG:
+
+- Scripts without Episode/Season fields will work fine
+- The Season/Episode columns will show "-" in the index
+- You can add these fields manually if needed for TV series organization
+- All standard Fountain formatting is fully supported
+
 ## Additional Resources
 
-- [Fountain Format Specification](https://fountain.io/)
+- [Official Fountain Format Specification](https://fountain.io/syntax)
+- [Fountain Title Page Documentation](https://fountain.io/syntax#section-titlepage)
 - [ScriptRAG Usage Guide](usage.md)
 - [Troubleshooting Guide](troubleshooting.md)

--- a/docs/fountain-tv-format.md
+++ b/docs/fountain-tv-format.md
@@ -34,10 +34,13 @@ ScriptRAG uses Episode and Season fields to:
 2. **Track character arcs** across episodes and seasons
 3. **Analyze pacing and structure** within a series context
 4. **Enable filtering and searching** by season/episode
+5. **Support Git-native workflows** by tracking episode changes across versions
 
-While these fields won't affect how your script renders in other Fountain tools, they provide essential metadata for ScriptRAG's analysis features.
+These fields integrate seamlessly with ScriptRAG's Git-native architecture, allowing writers to track the evolution of individual episodes through version control while maintaining series-wide context. While these fields won't affect how your script renders in other Fountain tools, they provide essential metadata for ScriptRAG's analysis features.
 
-## Required Format for ScriptRAG\n\n### Example with ScriptRAG Extensions
+## Required Format for ScriptRAG
+
+### Example with ScriptRAG Extensions
 
 ```fountain
 Title: Show Name - Episode Title


### PR DESCRIPTION
## Summary
- Enhances documentation for ScriptRAG's handling of TV script metadata
- Distinguishes between official Fountain title page fields and ScriptRAG-specific extensions
- Explains the purpose and usage of `Episode:` and `Season:` fields unique to ScriptRAG
- Adds guidance on script portability when importing/exporting Fountain scripts with these extensions

## Changes

### Documentation Updates
- Added a clear section differentiating official Fountain title page fields from ScriptRAG custom fields
- Detailed the reasons ScriptRAG uses `Episode:` and `Season:` fields for TV series organization and analysis
- Provided examples of required format including these extensions
- Included notes on how these fields affect script portability with other Fountain tools
- Updated links to official Fountain specification and title page documentation

## Test plan
- Reviewed documentation for clarity and completeness
- Verified example formatting is consistent with ScriptRAG requirements
- Confirmed links and references are accurate and up to date

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/407d5924-a346-415b-b2a6-149dc0563ac0
