### PR TITLE
Remove obsolete skipped tests from test_search_builder.py

### DIFF
--- a/tests/unit/test_search_builder.py
+++ b/tests/unit/test_search_builder.py
@@ -363,22 +363,6 @@ class TestQueryBuilder:
         assert "WHERE" not in sql  # No conditions
         assert params == []  # No parameters
 
-    def test_add_dialogue_search_empty_character_conditions(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
-    def test_add_action_search_empty_character_conditions(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
-    def test_add_location_filters_empty_location_conditions(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
-    def test_add_character_only_search_empty_conditions(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
     def test_build_count_query_dialogue_empty_character_conditions(self) -> None:
         """Test build_count_query dialogue branch with empty character conditions."""
         search_query = SearchQuery(
@@ -471,59 +455,3 @@ class TestQueryBuilder:
         assert "SARAH" in params
         assert "%urgently%" in params
         assert params[-2:] == [20, 5]  # limit, offset
-
-    def test_add_project_filter_none(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
-    def test_add_project_filter_with_project(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
-    def test_add_season_episode_filters_single_episode(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
-    def test_add_season_episode_filters_none(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
-    def test_add_dialogue_search_no_dialogue(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
-    def test_add_dialogue_search_with_parenthetical(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
-    def test_add_action_search_no_query(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
-    def test_add_action_search_with_characters(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
-    def test_add_location_filters_none(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
-    def test_add_location_filters_empty_list(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
-    def test_add_character_only_search_no_characters(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
-    def test_add_character_only_search_with_dialogue(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
-    def test_add_character_only_search_with_text_query(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")
-
-    def test_add_character_only_search_with_action(self) -> None:
-        """Test skipped - private method moved to utilities."""
-        pytest.skip("Private method moved to utilities - test no longer applicable")


### PR DESCRIPTION
## Summary
- Cleans up the test suite by removing multiple skipped tests in `test_search_builder.py`
- These tests were skipped because the private methods they tested were moved to utilities and are no longer applicable

## Changes

### Test Cleanup
- Deleted 72 lines of skipped test functions that referenced moved private methods
- Removed redundant `pytest.skip` calls for tests that no longer apply
- Retained all active and relevant tests in the file

## Test plan
- Existing active tests in `test_search_builder.py` continue to run and pass
- No skipped tests remain in this file, improving test clarity and maintenance
- Confirmed no regressions by running the full test suite after removal

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e667885f-88a7-4f49-861e-4a14d02fec33