### PR TITLE
fix(database): correct CI path detection in readonly module

### DIFF
--- a/src/scriptrag/database/readonly.py
+++ b/src/scriptrag/database/readonly.py
@@ -62,7 +62,7 @@ def _is_temp_directory(db_path_str: str, path_parts: list[str]) -> bool:
 
     # Check for temp indicators in path or CI paths
     return any(indicator in path_lower for indicator in temp_indicators) or any(
-        ci_path in db_path_str for ci_path in ci_indicators
+        db_path_str.startswith(ci_path) for ci_path in ci_indicators
     )
 
 

--- a/tests/unit/test_readonly_mac_temp_detection.py
+++ b/tests/unit/test_readonly_mac_temp_detection.py
@@ -14,3 +14,67 @@ def test_is_temp_directory_detects_macos_private_var_folders():
 def test_is_temp_directory_detects_macos_private_var_tmp():
     path = "/private/var/tmp/test.db"
     assert _is_temp_directory(path, path.split("/")) is True
+
+
+@pytest.mark.unit
+def test_is_temp_directory_detects_ci_runner_path():
+    """Test that CI runner paths are correctly detected."""
+    path = "/home/runner/work/project/test.db"
+    assert _is_temp_directory(path, path.split("/")) is True
+
+
+@pytest.mark.unit
+def test_is_temp_directory_detects_github_workspace():
+    """Test that GitHub workspace paths are correctly detected."""
+    path = "/github/workspace/test.db"
+    assert _is_temp_directory(path, path.split("/")) is True
+
+
+@pytest.mark.unit
+def test_is_temp_directory_rejects_ci_path_in_middle():
+    """Test that CI paths embedded in the middle of a path are not detected.
+
+    This is a regression test for a bug where 'in' was used instead of 'startswith'
+    for CI path detection, causing false positives.
+    """
+    # This path contains '/home/runner/work/' but not at the start
+    path = "/var/data/home/runner/work/test.db"
+    assert _is_temp_directory(path, path.split("/")) is False
+
+
+@pytest.mark.unit
+def test_is_temp_directory_rejects_github_workspace_in_middle():
+    """Test that GitHub workspace paths embedded in the middle are not detected.
+
+    This is a regression test for a bug where 'in' was used instead of 'startswith'
+    for CI path detection, causing false positives.
+    """
+    # This path contains '/github/workspace/' but not at the start
+    path = "/data/github/workspace/test.db"
+    assert _is_temp_directory(path, path.split("/")) is False
+
+
+@pytest.mark.unit
+def test_is_temp_directory_detects_temp_indicators():
+    """Test that general temp indicators are detected anywhere in path."""
+    # These should be detected anywhere in the path
+    paths = [
+        "/var/tmp/test.db",
+        "/home/user/temp/test.db",
+        "/data/pytest/test.db",
+        "/cache/.pytest_cache/test.db",
+    ]
+    for path in paths:
+        assert _is_temp_directory(path, path.split("/")) is True
+
+
+@pytest.mark.unit
+def test_is_temp_directory_rejects_non_temp_paths():
+    """Test that non-temp paths are not detected as temp."""
+    paths = [
+        "/var/lib/database.db",
+        "/home/user/data/production.db",
+        "/opt/application/db.sqlite",
+    ]
+    for path in paths:
+        assert _is_temp_directory(path, path.split("/")) is False


### PR DESCRIPTION
## Summary
- Fixed bug where CI paths were incorrectly matched anywhere in a path
- Changed from using `in` operator to `startswith` for proper prefix matching
- Added comprehensive unit tests with regression tests

## Details

Previously, the `_is_temp_directory` function incorrectly used `ci_path in db_path_str` which would match CI paths like `/home/runner/work/` anywhere in the path string. This caused false positives where paths like `/var/data/home/runner/work/test.db` would be incorrectly identified as temporary directories.

The fix changes this to use `db_path_str.startswith(ci_path)` to ensure CI paths are only matched at the beginning of the path string.

## Test plan
- [x] Added unit tests for correct CI path detection at start of path
- [x] Added regression tests to ensure CI paths in middle of path are rejected
- [x] Added tests for general temp indicators and non-temp paths
- [x] All existing tests continue to pass
- [x] Code passes linting and type checking

🤖 Generated with [Claude Code](https://claude.ai/code)