### PR TITLE
Use public logging API getLevelNamesMapping and add comprehensive tests

### DIFF
--- a/src/scriptrag/config/logging.py
+++ b/src/scriptrag/config/logging.py
@@ -44,13 +44,15 @@ def configure_logging(settings: ScriptRAGSettings) -> None:
         log_level = getattr(logging, settings.log_level.upper())
     except AttributeError as e:
         # Provide a helpful error message if an invalid log level somehow gets through
-        # Use dynamic list from logging module to avoid hard-coding
-        valid_levels = [
-            name for name in logging._nameToLevel if not name.startswith("_")
-        ]
+        # Use public API from logging module to get valid levels (Python 3.11+)
+        valid_levels = list(logging.getLevelNamesMapping().keys())
+        # Filter out numeric aliases and sort
+        valid_levels = sorted(
+            [level for level in valid_levels if not level.startswith("_")]
+        )
         raise ValueError(
             f"Invalid log level '{settings.log_level}'. "
-            f"Valid levels are: {', '.join(sorted(valid_levels))}"
+            f"Valid levels are: {', '.join(valid_levels)}"
         ) from e
 
     # Create formatters based on settings

--- a/tests/unit/test_logging_configuration.py
+++ b/tests/unit/test_logging_configuration.py
@@ -238,7 +238,8 @@ class TestLoggingConfiguration:
         # Verify it includes dynamically fetched valid levels from logging module
         import logging as log_module
 
-        for level_name in log_module._nameToLevel:
+        # Use public API to get valid levels (Python 3.11+)
+        for level_name in log_module.getLevelNamesMapping():
             if not level_name.startswith("_"):
                 assert level_name in error_msg, f"Missing {level_name} in error message"
 
@@ -294,8 +295,13 @@ class TestLoggingConfiguration:
         # Verify it lists levels in sorted order
         import logging as log_module
 
+        # Use public API to get valid levels (Python 3.11+)
         expected_levels = sorted(
-            [name for name in log_module._nameToLevel if not name.startswith("_")]
+            [
+                name
+                for name in log_module.getLevelNamesMapping()
+                if not name.startswith("_")
+            ]
         )
         levels_str = ", ".join(expected_levels)
         assert levels_str in error_msg

--- a/tests/unit/test_logging_public_api.py
+++ b/tests/unit/test_logging_public_api.py
@@ -1,0 +1,217 @@
+"""Tests for logging configuration using public API only.
+
+This test module ensures we use only public logging module APIs
+and avoid accessing private attributes like _nameToLevel.
+"""
+
+import logging
+import sys
+from unittest.mock import patch
+
+import pytest
+import structlog
+
+from scriptrag.config import ScriptRAGSettings, configure_logging
+
+
+@pytest.fixture(autouse=True)
+def clean_logging():
+    """Reset logging configuration before and after each test."""
+    # Reset structlog configuration
+    structlog.reset_defaults()
+
+    # Clear all handlers from root logger and reset level
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+    root_logger.setLevel(logging.WARNING)
+
+    yield
+
+    # Clean up again
+    structlog.reset_defaults()
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+    root_logger.setLevel(logging.WARNING)
+
+
+class TestLoggingPublicAPI:
+    """Test that logging configuration uses only public APIs."""
+
+    def test_get_level_names_mapping_is_public_api(self):
+        """Verify that getLevelNamesMapping is a public API in Python 3.11+."""
+        # This should exist in Python 3.11+
+        assert hasattr(logging, "getLevelNamesMapping")
+
+        # It should return a dict
+        level_names = logging.getLevelNamesMapping()
+        assert isinstance(level_names, dict)
+
+        # It should contain standard levels
+        assert "DEBUG" in level_names
+        assert "INFO" in level_names
+        assert "WARNING" in level_names
+        assert "ERROR" in level_names
+        assert "CRITICAL" in level_names
+
+    def test_invalid_log_level_uses_public_api(self):
+        """Test that invalid log level error uses public API for level names."""
+        # Create settings with invalid log level bypassing validation
+        settings = ScriptRAGSettings.__new__(ScriptRAGSettings)
+        object.__setattr__(settings, "log_level", "FAKE_LEVEL")
+        object.__setattr__(settings, "log_format", "console")
+        object.__setattr__(settings, "log_file", None)
+        object.__setattr__(settings, "debug", False)
+
+        with pytest.raises(ValueError) as exc_info:
+            configure_logging(settings)
+
+        error_msg = str(exc_info.value)
+
+        # Should contain the invalid level
+        assert "Invalid log level 'FAKE_LEVEL'" in error_msg
+        assert "Valid levels are:" in error_msg
+
+        # Should list all valid levels from public API
+        public_levels = logging.getLevelNamesMapping()
+        for level_name in public_levels:
+            if not level_name.startswith("_"):
+                assert level_name in error_msg
+
+    def test_valid_levels_sorted_correctly(self):
+        """Test that valid levels are listed in sorted order in error messages."""
+        settings = ScriptRAGSettings.__new__(ScriptRAGSettings)
+        object.__setattr__(settings, "log_level", "INVALID")
+        object.__setattr__(settings, "log_format", "console")
+        object.__setattr__(settings, "log_file", None)
+        object.__setattr__(settings, "debug", False)
+
+        with pytest.raises(ValueError) as exc_info:
+            configure_logging(settings)
+
+        error_msg = str(exc_info.value)
+
+        # Extract the levels from the error message
+        # Expected format: "Valid levels are: CRITICAL, DEBUG, ERROR, ..."
+        levels_part = error_msg.split("Valid levels are: ")[1]
+        listed_levels = [level.strip() for level in levels_part.split(",")]
+
+        # They should be in alphabetical order
+        assert listed_levels == sorted(listed_levels)
+
+    def test_no_private_api_access_in_logging_module(self):
+        """Ensure our logging module doesn't access private _nameToLevel."""
+        # Read the logging.py module to check
+        import inspect
+
+        import scriptrag.config.logging as logging_module
+
+        # Get the source code
+        source = inspect.getsource(logging_module)
+
+        # Should not contain references to private _nameToLevel
+        assert "_nameToLevel" not in source, (
+            "logging.py should not use private _nameToLevel API"
+        )
+
+        # Should use the public API instead
+        assert "getLevelNamesMapping" in source, (
+            "logging.py should use public getLevelNamesMapping API"
+        )
+
+    def test_error_message_completeness(self):
+        """Test that error message includes all standard log levels."""
+        settings = ScriptRAGSettings.__new__(ScriptRAGSettings)
+        object.__setattr__(settings, "log_level", "BOGUS")
+        object.__setattr__(settings, "log_format", "console")
+        object.__setattr__(settings, "log_file", None)
+        object.__setattr__(settings, "debug", False)
+
+        with pytest.raises(ValueError) as exc_info:
+            configure_logging(settings)
+
+        error_msg = str(exc_info.value)
+
+        # Standard levels that must be present
+        standard_levels = ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"]
+        for level in standard_levels:
+            assert level in error_msg, (
+                f"Standard level {level} missing from error message"
+            )
+
+    def test_public_api_compatibility(self):
+        """Test that our usage of getLevelNamesMapping is compatible."""
+        # Get levels using the public API
+        level_mapping = logging.getLevelNamesMapping()
+
+        # Verify we can filter and sort as expected
+        valid_levels = sorted(
+            [level for level in level_mapping if not level.startswith("_")]
+        )
+
+        # Should have at least the standard levels
+        assert len(valid_levels) >= 6  # NOTSET, DEBUG, INFO, WARNING, ERROR, CRITICAL
+
+        # Should be sortable (all strings)
+        assert all(isinstance(level, str) for level in valid_levels)
+
+    @patch("logging.getLevelNamesMapping")
+    def test_handles_future_logging_levels(self, mock_get_levels):
+        """Test that code handles potential future logging levels gracefully."""
+        # Mock a future Python version with additional log levels
+        mock_get_levels.return_value = {
+            "CRITICAL": 50,
+            "ERROR": 40,
+            "WARNING": 30,
+            "INFO": 20,
+            "DEBUG": 10,
+            "TRACE": 5,  # Hypothetical future level
+            "NOTSET": 0,
+        }
+
+        settings = ScriptRAGSettings.__new__(ScriptRAGSettings)
+        object.__setattr__(settings, "log_level", "INVALID")
+        object.__setattr__(settings, "log_format", "console")
+        object.__setattr__(settings, "log_file", None)
+        object.__setattr__(settings, "debug", False)
+
+        with pytest.raises(ValueError) as exc_info:
+            configure_logging(settings)
+
+        error_msg = str(exc_info.value)
+
+        # Should include the hypothetical TRACE level
+        assert "TRACE" in error_msg
+
+        # Should still be sorted
+        levels_part = error_msg.split("Valid levels are: ")[1]
+        listed_levels = [level.strip() for level in levels_part.split(",")]
+        assert listed_levels == sorted(listed_levels)
+
+    def test_python_version_compatibility(self):
+        """Verify Python version is 3.11+ for getLevelNamesMapping."""
+
+        # We require Python 3.11+ for getLevelNamesMapping
+        assert sys.version_info >= (3, 11), (
+            "Python 3.11+ required for getLevelNamesMapping"
+        )
+
+        # The API should be available
+        assert hasattr(logging, "getLevelNamesMapping")
+
+    def test_logging_module_imports_correctly(self):
+        """Test that our logging module can be imported without issues."""
+        # This should not raise any errors
+        from scriptrag.config import logging as config_logging
+
+        # Should have the configure_logging function
+        assert hasattr(config_logging, "configure_logging")
+        assert hasattr(config_logging, "get_logger")
+
+        # Should be able to call with valid settings
+        settings = ScriptRAGSettings(log_level="INFO")
+        config_logging.configure_logging(settings)
+
+        # Root logger should be configured
+        root_logger = logging.getLogger()
+        assert root_logger.level == logging.INFO


### PR DESCRIPTION
## Summary
- Replaced private logging attribute `_nameToLevel` with public API `getLevelNamesMapping` in logging configuration
- Updated error messages to list valid log levels using the public API
- Added extensive unit tests to ensure only public logging APIs are used and error messages are accurate

## Changes

### Core Functionality
- Modified `configure_logging` to fetch valid log levels via `logging.getLevelNamesMapping()` instead of private attributes
- Updated error handling to display sorted, filtered valid log levels from the public API

### Tests
- Enhanced existing tests in `test_logging_configuration.py` to verify usage of public API
- Added new test module `test_logging_public_api.py` with 217 lines covering:
  - Verification that `getLevelNamesMapping` is a public API available in Python 3.11+
  - Validation that invalid log level errors use the public API for level names
  - Checks for sorted order and completeness of valid log levels in error messages
  - Ensuring no private logging attributes are accessed in the codebase
  - Compatibility tests for future logging levels and Python version requirements
  - Tests for proper logging module import and configuration

## Test plan
- [x] Run all unit tests to confirm no regressions
- [x] Verify error messages for invalid log levels include all valid levels from the public API
- [x] Confirm no usage of private logging attributes in source code
- [x] Validate compatibility with Python 3.11+ logging API

This change improves code maintainability and forward compatibility by relying solely on the public logging API.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/afda5af5-c82b-4bc8-aa5b-6cd90249e93f