### PR TITLE
Cleanup legacy code and rename cache cleanup method

### DIFF
--- a/src/scriptrag/api/bible_extraction.py
+++ b/src/scriptrag/api/bible_extraction.py
@@ -238,7 +238,3 @@ class BibleExtractor:
 
         # Merge results
         return self.formatter.merge_results(character_result, scene_result)
-
-
-# Legacy alias for backward compatibility
-BibleCharacterExtractor = BibleExtractor

--- a/src/scriptrag/api/embedding_service.py
+++ b/src/scriptrag/api/embedding_service.py
@@ -292,7 +292,7 @@ class EmbeddingService:
         Returns:
             Number of cache files removed
         """
-        return self.cache.cleanup_old(max_age_days)
+        return self.cache.cleanup_old_entries(max_age_days)
 
     async def generate_batch_embeddings(
         self,

--- a/src/scriptrag/embeddings/cache.py
+++ b/src/scriptrag/embeddings/cache.py
@@ -414,7 +414,7 @@ class EmbeddingCache:
             else 0,
         }
 
-    def cleanup_old(self, max_age_days: int = 30) -> int:
+    def cleanup_old_entries(self, max_age_days: int = 30) -> int:
         """Remove cache entries older than specified age.
 
         Args:

--- a/tests/integration/test_bible_character_extraction.py
+++ b/tests/integration/test_bible_character_extraction.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from scriptrag.api.bible_extraction import BibleCharacterExtractor
+from scriptrag.api.bible_extraction import BibleExtractor
 
 
 @pytest.fixture
@@ -89,7 +89,7 @@ class TestBibleCharacterExtraction:
         completion_response.usage = {}
         mock_llm.complete = AsyncMock(return_value=completion_response)
 
-        extractor = BibleCharacterExtractor(llm_client=mock_llm)
+        extractor = BibleExtractor(llm_client=mock_llm)
         result = await extractor.extract_characters_from_bible(temp_bible_file)
 
         # Check structure
@@ -144,7 +144,7 @@ class TestBibleCharacterExtraction:
         completion_response.usage = {}
         mock_llm.complete = AsyncMock(return_value=completion_response)
 
-        extractor = BibleCharacterExtractor(llm_client=mock_llm)
+        extractor = BibleExtractor(llm_client=mock_llm)
         result = await extractor.extract_characters_from_bible(temp_bible_file)
 
         characters = result["characters"]
@@ -172,7 +172,7 @@ class TestBibleCharacterExtraction:
         mock_llm = AsyncMock(
             spec=["complete", "cleanup", "embed", "list_models", "is_available"]
         )
-        extractor = BibleCharacterExtractor(llm_client=mock_llm)
+        extractor = BibleExtractor(llm_client=mock_llm)
 
         result = await extractor.extract_characters_from_bible(bible_path)
 
@@ -193,7 +193,7 @@ class TestBibleCharacterExtraction:
         )
         mock_llm.complete = AsyncMock(side_effect=Exception("LLM API error"))
 
-        extractor = BibleCharacterExtractor(llm_client=mock_llm)
+        extractor = BibleExtractor(llm_client=mock_llm)
         result = await extractor.extract_characters_from_bible(temp_bible_file)
 
         # Should return empty result on failure
@@ -215,7 +215,7 @@ class TestBibleCharacterExtraction:
         mock_response.usage = {}
         mock_llm.complete = AsyncMock(return_value=mock_response)
 
-        extractor = BibleCharacterExtractor(llm_client=mock_llm)
+        extractor = BibleExtractor(llm_client=mock_llm)
         result = await extractor.extract_characters_from_bible(temp_bible_file)
 
         # Should handle gracefully
@@ -248,7 +248,7 @@ These are the main characters from the Bible."""
         completion_response.usage = {}
         mock_llm.complete = AsyncMock(return_value=completion_response)
 
-        extractor = BibleCharacterExtractor(llm_client=mock_llm)
+        extractor = BibleExtractor(llm_client=mock_llm)
         result = await extractor.extract_characters_from_bible(temp_bible_file)
 
         # Should extract JSON successfully
@@ -299,7 +299,7 @@ ALICE - Supporting character
         completion_response.usage = {}
         mock_llm.complete = AsyncMock(return_value=completion_response)
 
-        extractor = BibleCharacterExtractor(llm_client=mock_llm)
+        extractor = BibleExtractor(llm_client=mock_llm)
         result = await extractor.extract_characters_from_bible(bible_path)
 
         # Should find all character sections

--- a/tests/unit/embeddings/test_cache.py
+++ b/tests/unit/embeddings/test_cache.py
@@ -576,7 +576,7 @@ class TestEmbeddingCache:
         assert len(cache._index) == 2
 
         # Cleanup entries older than 30 days
-        count = cache.cleanup_old(max_age_days=30)
+        count = cache.cleanup_old_entries(max_age_days=30)
         assert count == 1
         assert len(cache._index) == 1
 
@@ -589,7 +589,7 @@ class TestEmbeddingCache:
         cache.put("text1", "model", [0.1])
         cache.put("text2", "model", [0.2])
 
-        count = cache.cleanup_old(max_age_days=30)
+        count = cache.cleanup_old_entries(max_age_days=30)
         assert count == 0
         assert len(cache._index) == 2
 
@@ -608,7 +608,7 @@ class TestEmbeddingCache:
         monkeypatch.setattr(Path, "unlink", mock_unlink)
 
         # Cleanup should handle errors gracefully
-        count = cache.cleanup_old(max_age_days=30)
+        count = cache.cleanup_old_entries(max_age_days=30)
         # Count might be 0 due to file removal error, but index should be cleaned
         assert key not in cache._index
 

--- a/tests/unit/embeddings/test_embeddings_comprehensive.py
+++ b/tests/unit/embeddings/test_embeddings_comprehensive.py
@@ -724,7 +724,7 @@ class TestEmbeddingCache:
         assert "model-b" in stats["models"]
         assert stats["strategy"] == "lru"
 
-    def test_cleanup_old(self, embedding_cache):
+    def test_cleanup_old_entries(self, embedding_cache):
         """Removing aged memories from the palace."""
         embedding = [0.1, 0.2, 0.3]
 
@@ -735,7 +735,7 @@ class TestEmbeddingCache:
         # Make it appear very old
         embedding_cache._index[key].timestamp = time.time() - (31 * 86400)
 
-        count = embedding_cache.cleanup_old(max_age_days=30)
+        count = embedding_cache.cleanup_old_entries(max_age_days=30)
         assert count == 1
 
         assert embedding_cache.get("old_text", "model") is None

--- a/tests/unit/test_bible_extraction_complete_coverage.py
+++ b/tests/unit/test_bible_extraction_complete_coverage.py
@@ -11,7 +11,7 @@ from scriptrag.api.bible.character_bible import (
     BibleCharacterExtractor as RealBibleCharacterExtractor,
 )
 from scriptrag.api.bible.scene_bible import BibleScene
-from scriptrag.api.bible_extraction import BibleCharacterExtractor, BibleExtractor
+from scriptrag.api.bible_extraction import BibleExtractor
 from scriptrag.parser.bible_parser import BibleChunk, ParsedBible
 
 
@@ -81,7 +81,7 @@ class TestBibleCharacter:
         assert char.notes is None
 
 
-class TestBibleCharacterExtractor:
+class TestRealBibleCharacterExtractor:
     """Test REAL BibleCharacterExtractor class from bible.character_bible."""
 
     def test_init_with_llm_client(self) -> None:
@@ -279,7 +279,7 @@ class TestBibleCharacterExtractor:
         )
         mock_client.complete = AsyncMock(return_value=mock_response)
 
-        extractor = BibleCharacterExtractor(llm_client=mock_client)
+        extractor = BibleExtractor(llm_client=mock_client)
         characters = await extractor._extract_via_llm(chunks)
 
         assert len(characters) == 1
@@ -298,7 +298,7 @@ class TestBibleCharacterExtractor:
         mock_client = AsyncMock()
         mock_client.complete.side_effect = Exception("LLM error")
 
-        extractor = BibleCharacterExtractor(llm_client=mock_client)
+        extractor = BibleExtractor(llm_client=mock_client)
         characters = await extractor._extract_via_llm(chunks)
 
         assert characters == []
@@ -320,7 +320,7 @@ class TestBibleCharacterExtractor:
         )
         mock_client.complete = AsyncMock(return_value=mock_response)
 
-        extractor = BibleCharacterExtractor(llm_client=mock_client)
+        extractor = BibleExtractor(llm_client=mock_client)
         characters = await extractor._extract_via_llm(chunks)
 
         assert characters == []
@@ -335,7 +335,7 @@ class TestBibleCharacterExtractor:
         mock_response = json.dumps([{"canonical": "JANE", "aliases": ["J"]}])
         mock_client.complete = AsyncMock(return_value=mock_response)
 
-        extractor = BibleCharacterExtractor(llm_client=mock_client)
+        extractor = BibleExtractor(llm_client=mock_client)
         characters = await extractor._extract_via_llm(chunks)
 
         assert len(characters) == 1
@@ -752,19 +752,4 @@ class TestBibleExtractor:
             assert scene["location"] == "POLICE STATION"
 
 
-class TestBibleExtractorLegacyAlias:
-    """Test the legacy BibleCharacterExtractor alias."""
-
-    def test_legacy_alias_is_same_class(self) -> None:
-        """Test that BibleCharacterExtractor is an alias for BibleExtractor."""
-        # This tests line 244 which defines the legacy alias
-        assert BibleCharacterExtractor is BibleExtractor
-
-    def test_legacy_alias_initialization(self) -> None:
-        """Test initialization through legacy alias."""
-        mock_client = Mock(spec=object)
-        extractor = BibleCharacterExtractor(llm_client=mock_client)
-
-        # Should be same type as BibleExtractor
-        assert isinstance(extractor, BibleExtractor)
-        assert extractor.llm_client is mock_client
+# Legacy alias tests removed - BibleCharacterExtractor alias has been removed

--- a/tests/unit/test_vss_service.py
+++ b/tests/unit/test_vss_service.py
@@ -424,8 +424,3 @@ class TestVSSService:
                 assert "Failed to search similar scenes" in str(exc_info.value)
                 # Verify the connection was properly cleaned up
                 mock_conn.close.assert_called_once()
-
-    # Migration function has been removed - no longer needed in pre-production
-    # def test_migrate_from_blob_storage(self, vss_service):
-    #     """Test migration from old BLOB storage."""
-    #     pass

--- a/tests/unit/test_vss_service_coverage.py
+++ b/tests/unit/test_vss_service_coverage.py
@@ -335,16 +335,6 @@ class TestVSSServiceExtended:
                 )
             assert "Failed to search similar bible chunks" in str(exc_info.value)
 
-    # Migration tests removed - migration function no longer exists
-    # def test_migrate_no_old_table(self, vss_service):
-    #     pass
-
-    # def test_migrate_with_bible_chunks(self, vss_service):
-    #     pass
-
-    # def test_migrate_with_corrupted_data(self, vss_service):
-    #     pass
-
     def test_initialize_vss_tables_with_migration_file(self, mock_settings, tmp_path):
         """Test VSS table initialization with migration file."""
         db_path = tmp_path / "test.db"


### PR DESCRIPTION
## Summary
- Removed legacy alias `BibleCharacterExtractor` for `BibleExtractor` to simplify codebase
- Renamed `cleanup_old` method to `cleanup_old_entries` in `EmbeddingCache` and updated all references
- Removed tests related to legacy alias and migration functions no longer needed
- Updated imports and test cases to use `BibleExtractor` directly

## Changes

### Core Functionality
- Deleted legacy alias `BibleCharacterExtractor` from `bible_extraction.py`
- Renamed `cleanup_old` to `cleanup_old_entries` in `embedding_service.py` and `cache.py`
- Updated all test files to reflect method renaming and removed legacy alias usage

### Tests
- Removed legacy alias tests from `test_bible_extraction_complete_coverage.py`
- Removed migration-related tests from `test_vss_service.py` and `test_vss_service_coverage.py`
- Updated all test imports and instantiations to use `BibleExtractor` instead of `BibleCharacterExtractor`

## Test plan
- All existing tests updated to reflect method renaming and alias removal
- Verified no references to legacy alias remain
- Confirmed all tests pass with updated method names and class references

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a204ab2b-7fa5-428d-83d8-2ecb59cb4e21