### PR TITLE
Fix readonly context manager to reset PRAGMA and add robust tests

### DIFF
--- a/src/scriptrag/database/connection_manager.py
+++ b/src/scriptrag/database/connection_manager.py
@@ -462,9 +462,13 @@ class DatabaseConnectionManager:
         try:
             # Set to read-only mode using PRAGMA
             conn.execute("PRAGMA query_only = ON")
-            yield conn
+            try:
+                yield conn
+            finally:
+                # Always reset query_only mode, even if an exception occurred
+                conn.execute("PRAGMA query_only = OFF")
         finally:
-            conn.execute("PRAGMA query_only = OFF")
+            # Always release the connection back to the pool
             self.release_connection(conn)
 
     @contextmanager


### PR DESCRIPTION
## Summary
- Fixes the `readonly` context manager in `DatabaseConnectionManager` to ensure `PRAGMA query_only` is always reset even if exceptions occur
- Adds comprehensive unit tests to verify correct behavior of the readonly context, including exception handling, connection release, and nested exceptions

## Changes

### Core Fix
- Modified `readonly` context manager to use nested `try`/`finally` blocks:
  - Sets `PRAGMA query_only = ON` before yielding connection
  - Ensures `PRAGMA query_only = OFF` is executed after usage regardless of exceptions
  - Releases connection back to pool in outer `finally` block

### Tests Added
- `test_readonly_context_exception_handling`: Verifies connections are released and exceptions propagate correctly
- `test_readonly_context_query_only_reset`: Confirms `query_only` mode is reset after exceptions
- `test_readonly_context_nested_exceptions`: Tests multiple exception types and ensures pool remains healthy

## Test plan
- Run all new and existing unit tests in `tests/unit/database/test_connection_manager.py` to verify no regressions
- Confirm that connection pool stats remain consistent after exceptions in readonly context
- Validate that database operations succeed after readonly context usage

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/de366785-8a0d-49a3-aff9-114152ad36c7