### PR TITLE
Fix type signature and None handling in SceneValidator

### DIFF
--- a/src/scriptrag/validators/scene_validator.py
+++ b/src/scriptrag/validators/scene_validator.py
@@ -322,15 +322,15 @@ class SceneValidator:
 
     def check_scene_conflicts(
         self,
-        new_content: str,
-        existing_content: str,
+        new_content: str | None,
+        existing_content: str | None,
         _last_modified: Any | None = None,
     ) -> ValidationResult:
         """Check for conflicts between new and existing scene content.
 
         Args:
-            new_content: New scene content
-            existing_content: Existing scene content
+            new_content: New scene content (can be None)
+            existing_content: Existing scene content (can be None)
             _last_modified: Last modification timestamp (reserved for future use)
 
         Returns:

--- a/tests/validators/test_scene_validator.py
+++ b/tests/validators/test_scene_validator.py
@@ -211,24 +211,23 @@ Some action."""
     def test_check_scene_conflicts_none_handling(
         self, validator: SceneValidator
     ) -> None:
-        """Test conflict checking with None values (despite type hints)."""
-        # Test that None is handled gracefully even though type hints say str
-        # This tests defensive programming against runtime type issues
+        """Test conflict checking with None values."""
+        # Test that None is handled gracefully as per the type signature
 
         # Both None (treated as empty)
-        result = validator.check_scene_conflicts(None, None)  # type: ignore
+        result = validator.check_scene_conflicts(None, None)
         assert result.is_valid is True
         assert result.metadata["has_changes"] is False
         assert "No changes detected" in result.warnings[0]
 
         # One None, one with content
         content = "INT. OFFICE - DAY\n\nAction."
-        result = validator.check_scene_conflicts(None, content)  # type: ignore
+        result = validator.check_scene_conflicts(None, content)
         assert result.is_valid is True
         assert result.metadata["has_changes"] is True
         assert "Scene content removed" in result.warnings
 
-        result = validator.check_scene_conflicts(content, None)  # type: ignore
+        result = validator.check_scene_conflicts(content, None)
         assert result.is_valid is True
         assert result.metadata["has_changes"] is True
         assert "New scene content added" in result.warnings


### PR DESCRIPTION
## Summary
- Updated `check_scene_conflicts` method in `SceneValidator` to accept `None` for `new_content` and `existing_content` parameters
- Adjusted test cases to align with the updated type signature and ensure proper handling of `None` values

## Changes

### Core Functionality
- Modified `check_scene_conflicts` method signature to accept `str | None` for `new_content` and `existing_content`
- Updated docstring to reflect that these parameters can be `None`

### Tests
- Refactored `test_check_scene_conflicts_none_handling` to remove `type: ignore` comments
- Ensured tests verify correct behavior when `None` is passed, including:
  - Both parameters `None` treated as empty content
  - One parameter `None` and the other with content
- Confirmed validation results and warnings are as expected for these cases

## Test plan
- [x] Run existing tests to verify no regressions
- [x] Confirm tests for `None` handling pass successfully
- [x] Validate that type signature changes align with runtime behavior

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9a35967d-11ca-4980-8a92-3c4e9238e4be