### PR TITLE
Fix race condition in SearchEngine thread communication

### DIFF
--- a/tests/unit/test_search_engine_race_condition.py
+++ b/tests/unit/test_search_engine_race_condition.py
@@ -1,0 +1,285 @@
+"""Tests for search engine race condition bug fix.
+
+This test module specifically tests the fix for the race condition bug where
+the search thread was using nonlocal variables without proper synchronization,
+potentially leading to data corruption or unpredictable behavior.
+"""
+
+import asyncio
+import queue
+import sqlite3
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from scriptrag.config import ScriptRAGSettings
+from scriptrag.search.engine import SearchEngine
+from scriptrag.search.models import SearchMode, SearchQuery, SearchResponse
+
+
+class TestSearchEngineRaceCondition:
+    """Test SearchEngine thread-safe communication."""
+
+    @pytest.fixture
+    def mock_settings(self, tmp_path):
+        """Create mock settings."""
+        settings = MagicMock(spec=ScriptRAGSettings)
+        settings.database_path = tmp_path / "test.db"
+        settings.database_timeout = 30.0
+        settings.database_cache_size = 2000
+        settings.database_temp_store = "MEMORY"
+        settings.database_journal_mode = "WAL"
+        settings.database_synchronous = "NORMAL"
+        settings.database_mmap_size = 30000000000
+        settings.database_page_size = 4096
+        settings.database_busy_timeout = 3000
+        settings.database_foreign_keys = True
+        settings.database_autocommit = False
+        settings.search_vector_result_limit_factor = 0.5
+        settings.search_vector_min_results = 5
+        settings.search_vector_similarity_threshold = 0.5
+        settings.search_vector_threshold = 10
+        settings.llm_model_cache_ttl = 3600
+        settings.search_thread_timeout = 1.0  # Reasonable timeout for testing
+        return settings
+
+    @pytest.fixture
+    def mock_db(self, tmp_path):
+        """Create a mock database file."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db_path))
+
+        # Create minimal schema
+        conn.execute("""
+            CREATE TABLE scripts (
+                id INTEGER PRIMARY KEY,
+                title TEXT,
+                author TEXT,
+                created_at TEXT
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE scenes (
+                id INTEGER PRIMARY KEY,
+                script_id INTEGER,
+                scene_number INTEGER,
+                location TEXT,
+                content TEXT,
+                description TEXT,
+                FOREIGN KEY(script_id) REFERENCES scripts(id)
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE characters (
+                id INTEGER PRIMARY KEY,
+                script_id INTEGER,
+                name TEXT,
+                FOREIGN KEY(script_id) REFERENCES scripts(id)
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE dialogue (
+                id INTEGER PRIMARY KEY,
+                scene_id INTEGER,
+                character_id INTEGER,
+                line_number INTEGER,
+                text TEXT,
+                FOREIGN KEY(scene_id) REFERENCES scenes(id),
+                FOREIGN KEY(character_id) REFERENCES characters(id)
+            )
+        """)
+        conn.close()
+        return db_path
+
+    def test_thread_safe_communication_success(self, mock_settings, mock_db):
+        """Test that thread communication is thread-safe on success."""
+        mock_settings.database_path = mock_db
+        engine = SearchEngine(mock_settings)
+
+        # Mock a successful search result
+        test_query = SearchQuery(raw_query="test query", mode=SearchMode.SCENE)
+        expected_response = SearchResponse(query=test_query, results=[], total_count=0)
+
+        with patch.object(engine, "search_async", return_value=expected_response):
+            # Run search in a context with an event loop
+            # This forces the thread-based execution path
+            async def run_with_loop():
+                loop = asyncio.get_running_loop()
+                # Call search from within an async context
+                return await asyncio.to_thread(
+                    engine.search,
+                    SearchQuery(raw_query="test query", mode=SearchMode.SCENE),
+                )
+
+            result = asyncio.run(run_with_loop())
+            assert result == expected_response
+            assert result.query.raw_query == "test query"
+
+    def test_thread_safe_communication_exception(self, mock_settings, mock_db):
+        """Test that thread communication is thread-safe on exception."""
+        mock_settings.database_path = mock_db
+        engine = SearchEngine(mock_settings)
+
+        test_error = ValueError("Test error from async search")
+
+        with patch.object(engine, "search_async", side_effect=test_error):
+            # Run search in a context with an event loop
+            async def run_with_loop():
+                loop = asyncio.get_running_loop()
+                # Call search from within an async context
+                with pytest.raises(ValueError, match="Test error from async search"):
+                    await asyncio.to_thread(
+                        engine.search,
+                        SearchQuery(raw_query="test query", mode=SearchMode.SCENE),
+                    )
+
+            asyncio.run(run_with_loop())
+
+    def test_thread_timeout_handling(self, mock_settings, mock_db):
+        """Test that thread timeout is handled properly."""
+        mock_settings.database_path = mock_db
+        mock_settings.search_thread_timeout = 0.1  # Very short timeout
+        engine = SearchEngine(mock_settings)
+
+        # Create a search that will timeout
+        async def slow_search(query):
+            await asyncio.sleep(1.0)  # Sleep longer than timeout
+            return SearchResponse(query=query, results=[], total_count=0)
+
+        with patch.object(engine, "search_async", side_effect=slow_search):
+            # Run search in a context with an event loop
+            async def run_with_loop():
+                loop = asyncio.get_running_loop()
+                # Call search from within an async context
+                with pytest.raises(RuntimeError, match="Search operation timed out"):
+                    await asyncio.to_thread(
+                        engine.search,
+                        SearchQuery(raw_query="test query", mode=SearchMode.SCENE),
+                    )
+
+            asyncio.run(run_with_loop())
+
+    def test_no_result_produced_error(self, mock_settings, mock_db):
+        """Test that empty queue after thread completion raises error."""
+        mock_settings.database_path = mock_db
+        engine = SearchEngine(mock_settings)
+
+        # Mock search_async to not put anything in the queue
+        # This simulates a scenario where thread completes but no result produced
+        with patch("scriptrag.search.engine.queue.Queue") as mock_queue_class:
+            mock_queue_instance = Mock()
+            mock_queue_instance.get_nowait.side_effect = queue.Empty
+            mock_queue_class.return_value = mock_queue_instance
+
+            with patch.object(engine, "search_async"):
+                # Run search in a context with an event loop
+                async def run_with_loop():
+                    loop = asyncio.get_running_loop()
+                    # Call search from within an async context
+                    with pytest.raises(
+                        RuntimeError,
+                        match="Search thread completed but no result was produced",
+                    ):
+                        await asyncio.to_thread(
+                            engine.search,
+                            SearchQuery(raw_query="test query", mode=SearchMode.SCENE),
+                        )
+
+                asyncio.run(run_with_loop())
+
+    def test_concurrent_searches_thread_safety(self, mock_settings, mock_db):
+        """Test that multiple concurrent searches don't interfere with each other."""
+        mock_settings.database_path = mock_db
+        engine = SearchEngine(mock_settings)
+
+        results = []
+
+        def create_response(query_text):
+            """Create a unique response for each query."""
+            return SearchResponse(
+                query=SearchQuery(raw_query=query_text, mode=SearchMode.SCENE),
+                results=[],
+                total_count=len(query_text),  # Use length as a unique identifier
+            )
+
+        with patch.object(engine, "search_async") as mock_search:
+            mock_search.side_effect = lambda q: create_response(q.raw_query)
+
+            # Run multiple searches concurrently
+            async def run_concurrent_searches():
+                loop = asyncio.get_running_loop()
+
+                async def search_wrapper(query_text):
+                    return await asyncio.to_thread(
+                        engine.search,
+                        SearchQuery(raw_query=query_text, mode=SearchMode.SCENE),
+                    )
+
+                # Create multiple concurrent searches
+                tasks = [search_wrapper(f"query_{i}") for i in range(10)]
+
+                return await asyncio.gather(*tasks)
+
+            results = asyncio.run(run_concurrent_searches())
+
+            # Verify that each search got its correct result
+            assert len(results) == 10
+            for i, result in enumerate(results):
+                expected_query = f"query_{i}"
+                assert result.query.raw_query == expected_query
+                assert result.total_count == len(expected_query)
+
+    def test_queue_based_communication(self, mock_settings, mock_db):
+        """Test fix uses queue-based communication instead of nonlocal variables."""
+        mock_settings.database_path = mock_db
+
+        # Patch the queue module to verify it's being used
+        with patch("scriptrag.search.engine.queue.Queue") as mock_queue_class:
+            mock_queue_instance = Mock()
+            mock_result = SearchResponse(
+                query=SearchQuery(raw_query="test", mode=SearchMode.SCENE),
+                results=[],
+                total_count=0,
+            )
+            mock_queue_instance.get_nowait.return_value = mock_result
+            mock_queue_class.return_value = mock_queue_instance
+
+            engine = SearchEngine(mock_settings)
+
+            with patch.object(engine, "search_async", return_value=mock_result):
+                # Run search in a context with an event loop
+                async def run_with_loop():
+                    loop = asyncio.get_running_loop()
+                    return await asyncio.to_thread(
+                        engine.search,
+                        SearchQuery(raw_query="test", mode=SearchMode.SCENE),
+                    )
+
+                result = asyncio.run(run_with_loop())
+
+                # Verify queue was created and used
+                mock_queue_class.assert_called_once()
+                mock_queue_instance.put.assert_called_once_with(mock_result)
+                mock_queue_instance.get_nowait.assert_called_once()
+
+                assert result == mock_result
+
+    def test_search_without_event_loop(self, mock_settings, mock_db):
+        """Test that search works correctly when no event loop is running."""
+        mock_settings.database_path = mock_db
+        engine = SearchEngine(mock_settings)
+
+        expected_response = SearchResponse(
+            query=SearchQuery(raw_query="test query", mode=SearchMode.SCENE),
+            results=[],
+            total_count=0,
+        )
+
+        with patch.object(engine, "search_async", return_value=expected_response):
+            # Call search directly without any async context
+            result = engine.search(
+                SearchQuery(raw_query="test query", mode=SearchMode.SCENE)
+            )
+
+            assert result == expected_response
+            assert result.query.raw_query == "test query"


### PR DESCRIPTION
## Summary
- Fixed critical race condition in SearchEngine thread communication
- Replaced unsafe nonlocal variables with thread-safe queue.Queue
- Added comprehensive unit tests to verify thread-safe behavior

## Bug Details
The search engine had a race condition bug where `result` and `exception` variables were shared between threads using nonlocal without proper synchronization. This could lead to data corruption or unpredictable behavior under concurrent access.

## Solution
- Replace nonlocal variables with thread-safe `queue.Queue` for inter-thread communication
- Ensure atomic result passing between worker thread and main thread
- Add comprehensive unit tests to verify thread-safe behavior
- Test concurrent searches don't interfere with each other

## Testing
- Added 7 comprehensive unit tests covering various race condition scenarios
- All existing search engine tests pass
- Quality checks pass (ruff, mypy, etc.)
- Tests verify proper thread-safe communication

## Impact
This fix ensures thread-safe communication and prevents potential data corruption in multi-threaded search scenarios, improving the reliability of the search functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)