### PR TITLE
Add scene type filtering (INT/EXT/INT/EXT) to search queries

### DIFF
--- a/src/scriptrag/main.py
+++ b/src/scriptrag/main.py
@@ -212,15 +212,12 @@ class ScriptRAG:
         if location:
             parsed_query.locations = [location]
 
-        # Handle filters (basic implementation for test compatibility)
+        # Handle filters
         if filters and "scene_type" in filters:
             scene_type = filters["scene_type"]
-            # Filter by scene type (INT/EXT) by checking if location contains it
-            if scene_type in ["INT", "EXT"]:
-                # This is a simplified implementation for test compatibility
-                # The actual filtering would be handled at search engine level
-                # TODO: Implement scene type filtering in search engine
-                pass
+            # Filter by scene type (INT/EXT/INT/EXT)
+            if scene_type in ["INT", "EXT", "INT/EXT"]:
+                parsed_query.scene_type = scene_type
 
         logger.debug(f"Executing search: {parsed_query.raw_query}")
 

--- a/src/scriptrag/search/builder.py
+++ b/src/scriptrag/search/builder.py
@@ -64,6 +64,11 @@ class QueryBuilder:
             where_conditions, params, search_query.locations
         )
 
+        # Add scene type filter
+        self.filter_utils.add_scene_type_filter(
+            where_conditions, params, search_query.scene_type
+        )
+
         # Add character-only search (when searching for characters without text)
         if search_query.characters and not (
             search_query.dialogue or search_query.text_query or search_query.action
@@ -125,6 +130,11 @@ class QueryBuilder:
         # Add location filters
         self.filter_utils.add_location_filters(
             where_conditions, params, search_query.locations
+        )
+
+        # Add scene type filter
+        self.filter_utils.add_scene_type_filter(
+            where_conditions, params, search_query.scene_type
         )
 
         # Add character-only search

--- a/src/scriptrag/search/models.py
+++ b/src/scriptrag/search/models.py
@@ -42,6 +42,7 @@ class SearchQuery:
     offset: int = 0
     include_bible: bool = True  # Include bible content in search
     only_bible: bool = False  # Search only bible content
+    scene_type: str | None = None  # Filter by scene type (INT/EXT/INT/EXT)
 
     def __eq__(self, other: object) -> bool:
         """Allow comparison with strings for backwards compatibility."""

--- a/src/scriptrag/search/utils.py
+++ b/src/scriptrag/search/utils.py
@@ -99,6 +99,26 @@ class SearchFilterUtils:
             where_conditions.append(f"({' OR '.join(location_conditions)})")
 
     @staticmethod
+    def add_scene_type_filter(
+        where_conditions: list[str],
+        params: list[Any],
+        scene_type: str | None,
+    ) -> None:
+        """Add scene type filter to query.
+
+        Args:
+            where_conditions: List of WHERE conditions to append to
+            params: List of query parameters to append to
+            scene_type: Scene type to filter by (INT, EXT, INT/EXT)
+        """
+        if not scene_type:
+            return
+
+        # Scene headings typically start with INT., EXT., or INT/EXT.
+        where_conditions.append("sc.heading LIKE ?")
+        params.append(f"{scene_type}.%")
+
+    @staticmethod
     def add_character_filter(
         where_conditions: list[str],
         params: list[Any],

--- a/tests/unit/test_scene_type_filtering.py
+++ b/tests/unit/test_scene_type_filtering.py
@@ -1,0 +1,210 @@
+"""Comprehensive unit tests for scene type filtering functionality."""
+
+from unittest.mock import MagicMock, patch
+
+from scriptrag.main import ScriptRAG
+from scriptrag.search.builder import QueryBuilder
+from scriptrag.search.models import SearchQuery
+from scriptrag.search.utils import SearchFilterUtils
+
+
+class TestSceneTypeFiltering:
+    """Test scene type filtering across all layers of the application."""
+
+    def test_search_query_model_has_scene_type_field(self):
+        """Test that SearchQuery model includes scene_type field."""
+        query = SearchQuery(raw_query="test", scene_type="INT", limit=10, offset=0)
+        assert query.scene_type == "INT"
+        assert hasattr(query, "scene_type")
+
+    def test_search_query_scene_type_default_is_none(self):
+        """Test that scene_type defaults to None when not provided."""
+        query = SearchQuery(raw_query="test")
+        assert query.scene_type is None
+
+    def test_search_filter_utils_adds_scene_type_filter(self):
+        """Test SearchFilterUtils.add_scene_type_filter method."""
+        where_conditions = []
+        params = []
+
+        # Test with INT scene type
+        SearchFilterUtils.add_scene_type_filter(where_conditions, params, "INT")
+        assert len(where_conditions) == 1
+        assert "sc.heading LIKE ?" in where_conditions[0]
+        assert params == ["INT.%"]
+
+        # Reset and test with EXT
+        where_conditions = []
+        params = []
+        SearchFilterUtils.add_scene_type_filter(where_conditions, params, "EXT")
+        assert params == ["EXT.%"]
+
+        # Reset and test with INT/EXT
+        where_conditions = []
+        params = []
+        SearchFilterUtils.add_scene_type_filter(where_conditions, params, "INT/EXT")
+        assert params == ["INT/EXT.%"]
+
+    def test_search_filter_utils_ignores_none_scene_type(self):
+        """Test that None scene_type is properly ignored."""
+        where_conditions = []
+        params = []
+
+        SearchFilterUtils.add_scene_type_filter(where_conditions, params, None)
+        assert len(where_conditions) == 0
+        assert len(params) == 0
+
+    def test_query_builder_includes_scene_type_in_search_query(self):
+        """Test that QueryBuilder properly includes scene_type filter."""
+        builder = QueryBuilder()
+        query = SearchQuery(
+            raw_query="test", text_query="test", scene_type="INT", limit=10, offset=0
+        )
+
+        sql, params = builder.build_search_query(query)
+
+        # Check that scene type filter is included
+        assert "sc.heading LIKE ?" in sql
+        assert "INT.%" in params
+
+    def test_query_builder_includes_scene_type_in_count_query(self):
+        """Test that QueryBuilder includes scene_type in count query."""
+        builder = QueryBuilder()
+        query = SearchQuery(
+            raw_query="test", text_query="test", scene_type="EXT", limit=10, offset=0
+        )
+
+        sql, params = builder.build_count_query(query)
+
+        # Check that scene type filter is included
+        assert "sc.heading LIKE ?" in sql
+        assert "EXT.%" in params
+
+    def test_main_scriptrag_passes_scene_type_from_filters(self):
+        """Test that ScriptRAG.search properly handles scene_type in filters."""
+        with patch("scriptrag.main.SearchEngine") as mock_engine_class:
+            mock_engine = MagicMock()
+            mock_engine_class.return_value = mock_engine
+
+            # Create ScriptRAG instance
+            scriptrag = ScriptRAG(auto_init_db=False)
+
+            # Mock the database check
+            scriptrag.db_ops.check_database_exists = MagicMock(return_value=True)
+
+            # Mock the search method
+            mock_response = MagicMock()
+            mock_response.results = []
+            mock_response.total_count = 0
+            mock_engine.search.return_value = mock_response
+
+            # Call search with scene_type filter
+            scriptrag.search("test query", filters={"scene_type": "INT"})
+
+            # Verify that search was called with SearchQuery containing scene_type
+            mock_engine.search.assert_called_once()
+            search_query_arg = mock_engine.search.call_args[0][0]
+            assert isinstance(search_query_arg, SearchQuery)
+            assert search_query_arg.scene_type == "INT"
+
+    def test_main_scriptrag_handles_all_valid_scene_types(self):
+        """Test that all valid scene types are properly handled."""
+        with patch("scriptrag.main.SearchEngine") as mock_engine_class:
+            mock_engine = MagicMock()
+            mock_engine_class.return_value = mock_engine
+
+            scriptrag = ScriptRAG(auto_init_db=False)
+
+            # Mock the database check
+            scriptrag.db_ops.check_database_exists = MagicMock(return_value=True)
+
+            mock_response = MagicMock()
+            mock_response.results = []
+            mock_response.total_count = 0
+            mock_engine.search.return_value = mock_response
+
+            # Test INT
+            scriptrag.search("test", filters={"scene_type": "INT"})
+            assert mock_engine.search.call_args[0][0].scene_type == "INT"
+
+            # Test EXT
+            scriptrag.search("test", filters={"scene_type": "EXT"})
+            assert mock_engine.search.call_args[0][0].scene_type == "EXT"
+
+            # Test INT/EXT
+            scriptrag.search("test", filters={"scene_type": "INT/EXT"})
+            assert mock_engine.search.call_args[0][0].scene_type == "INT/EXT"
+
+    def test_main_scriptrag_ignores_invalid_scene_types(self):
+        """Test that invalid scene types are properly ignored."""
+        with patch("scriptrag.main.SearchEngine") as mock_engine_class:
+            mock_engine = MagicMock()
+            mock_engine_class.return_value = mock_engine
+
+            scriptrag = ScriptRAG(auto_init_db=False)
+
+            # Mock the database check
+            scriptrag.db_ops.check_database_exists = MagicMock(return_value=True)
+
+            mock_response = MagicMock()
+            mock_response.results = []
+            mock_response.total_count = 0
+            mock_engine.search.return_value = mock_response
+
+            # Test invalid scene type
+            scriptrag.search("test", filters={"scene_type": "INVALID"})
+
+            # Should not have scene_type set
+            search_query_arg = mock_engine.search.call_args[0][0]
+            assert search_query_arg.scene_type is None
+
+    def test_search_with_scene_type_and_other_filters(self):
+        """Test scene_type filtering combined with other filters."""
+        builder = QueryBuilder()
+        query = SearchQuery(
+            raw_query="coffee",
+            text_query="coffee",
+            scene_type="INT",
+            locations=["office"],
+            limit=10,
+            offset=0,
+        )
+
+        sql, params = builder.build_search_query(query)
+
+        # Check both filters are included
+        assert "sc.heading LIKE ?" in sql
+        assert "sc.location LIKE ?" in sql
+        assert "INT.%" in params
+        assert "%office%" in params
+
+    def test_scene_type_filter_preserves_existing_functionality(self):
+        """Test that adding scene_type doesn't break existing search functionality."""
+        builder = QueryBuilder()
+
+        # Query without scene_type (existing functionality)
+        query1 = SearchQuery(
+            raw_query="test", dialogue="hello", characters=["John"], limit=5, offset=0
+        )
+        sql1, params1 = builder.build_search_query(query1)
+
+        # Verify existing query still works
+        assert "d.dialogue_text LIKE ?" in sql1
+        assert "%hello%" in params1
+
+        # Query with scene_type (new functionality)
+        query2 = SearchQuery(
+            raw_query="test",
+            dialogue="hello",
+            characters=["John"],
+            scene_type="INT",
+            limit=5,
+            offset=0,
+        )
+        sql2, params2 = builder.build_search_query(query2)
+
+        # Verify both old and new filters work together
+        assert "d.dialogue_text LIKE ?" in sql2
+        assert "sc.heading LIKE ?" in sql2
+        assert "%hello%" in params2
+        assert "INT.%" in params2


### PR DESCRIPTION
## Summary
- Introduces scene type filtering support in search queries for scene headings starting with INT., EXT., or INT/EXT.
- Extends the `SearchQuery` model to include a `scene_type` field.
- Updates `ScriptRAG.search` to handle scene type filters from user input.
- Enhances `QueryBuilder` to incorporate scene type filters in both search and count queries.
- Implements `SearchFilterUtils.add_scene_type_filter` to add SQL conditions for scene type filtering.
- Adds comprehensive unit tests covering all layers of scene type filtering functionality.

## Changes

### Core Functionality
- **SearchQuery Model**: Added `scene_type` attribute to represent the scene type filter.
- **ScriptRAG Main Search**: Parses and applies scene type filters from the `filters` argument if valid (INT, EXT, INT/EXT).
- **QueryBuilder**: Injects scene type filtering conditions into SQL queries using the utility method.
- **SearchFilterUtils**: New static method `add_scene_type_filter` appends SQL WHERE clause and parameters for scene type.

### Testing
- Created `test_scene_type_filtering.py` with extensive unit tests:
  - Validates model field presence and default behavior.
  - Tests utility method for correct SQL condition generation.
  - Confirms query builder includes scene type filters in SQL.
  - Verifies main search method passes scene type correctly.
  - Checks handling of valid, invalid, and combined filters.
  - Ensures existing search functionality remains unaffected.

## Test plan
- Run all new and existing unit tests to verify scene type filtering correctness and integration.
- Confirm no regressions in search functionality without scene type filters.
- Validate that scene type filters correctly restrict search results based on scene headings.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7ea35f5c-8795-4451-9720-fb50904db932