### PR TITLE
Fix handling of bare git repositories in FileSourceResolver

### DIFF
--- a/src/scriptrag/common/file_source.py
+++ b/src/scriptrag/common/file_source.py
@@ -207,6 +207,10 @@ class FileSourceResolver:
 
             # Try to find git repo from current directory
             repo = git.Repo(".", search_parent_directories=True)
+            # Handle bare repositories or edge cases where working_dir is None
+            if repo.working_dir is None:
+                logger.debug("Git repository has no working directory (bare repo?)")
+                return None
             self._git_root = Path(repo.working_dir)
             logger.debug(f"Found git repository root: {self._git_root}")
             return self._git_root


### PR DESCRIPTION
## Summary
- Fixes a bug in `FileSourceResolver` where bare git repositories (with no working directory) caused a `TypeError` due to `Path(None)` being called.
- Adds defensive check to return `None` if the git repository has no working directory.
- Adds comprehensive unit tests to cover bare git repository scenarios and ensure no crashes occur.

## Changes

### Core Fix
- Modified `_find_git_root` method in `FileSourceResolver` to detect when `repo.working_dir` is `None` (bare repo) and return `None` early.
- Prevents attempts to create a `Path` object from `None`, avoiding `TypeError`.

### Tests
- Added `test_get_search_directories_bare_git_repo` to verify that search directories are returned gracefully when the git repo is bare.
- Added `test_git_repo_none_working_dir_edge_case` to ensure `_find_git_root` returns `None` and internal state remains consistent when `working_dir` is `None`.

## Test plan
- Run new and existing unit tests to confirm no regressions.
- Verify that no `TypeError` is raised when resolving file sources in bare git repositories.
- Confirm that default search directories are still returned in these edge cases.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/adb296e3-104a-4125-8b86-d47edaa94a67