### PR TITLE
Fix async query timeout handling in ClaudeCodeProvider

### DIFF
--- a/src/scriptrag/llm/providers/claude_code.py
+++ b/src/scriptrag/llm/providers/claude_code.py
@@ -382,13 +382,16 @@ class ClaudeCodeProvider(BaseLLMProvider):
         try:
             # Execute the query with a timeout
             query_timeout = DEFAULT_QUERY_TIMEOUT
-            async with asyncio.timeout(query_timeout):
+
+            async def _query_iterator() -> None:
                 async for message in query(prompt=prompt, options=options):
                     messages.append(message)
                     logger.debug(
                         "Received message from Claude Code SDK",
                         message_type=message.__class__.__name__,
                     )
+
+            await asyncio.wait_for(_query_iterator(), timeout=query_timeout)
 
             # Query completed, cancel progress monitoring
             progress_task.cancel()


### PR DESCRIPTION
## Summary
- Fixes the async query timeout handling in `ClaudeCodeProvider` by using `asyncio.wait_for` to properly enforce the timeout during async iteration
- Adds a new test to verify that timeouts during async iteration raise `TimeoutError` as expected

## Changes

### Core Functionality
- Refactored `_execute_query` method in `ClaudeCodeProvider` to wrap the async iterator in an inner async function `_query_iterator`
- Used `asyncio.wait_for` to run `_query_iterator` with the specified timeout, replacing the previous `asyncio.timeout` context manager

### Tests
- Added `test_execute_query_timeout_with_wait_for` in `test_claude_code.py` to simulate a hanging async iterator
- The test patches the query function to a hanging async generator and asserts that a `TimeoutError` is raised when the timeout is exceeded

## Test plan
- [x] Run the new async timeout test to ensure `TimeoutError` is raised correctly
- [x] Verify existing tests pass without regressions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e7d6f4b9-4ddc-4a1f-9a13-5d8d9b34b7b6