### PR TITLE
Fix handling of null and malformed messages in GitHubModelsProvider

### DIFF
--- a/src/scriptrag/llm/providers/github_models.py
+++ b/src/scriptrag/llm/providers/github_models.py
@@ -296,9 +296,14 @@ class GitHubModelsProvider(EnhancedBaseLLMProvider):
 
             for choice in raw_choices:
                 if isinstance(choice, dict):
+                    # Safely extract message, handling None case
+                    message_data = choice.get("message")
+                    if not isinstance(message_data, dict):
+                        message_data = {}
+
                     message: CompletionMessage = {
-                        "role": choice.get("message", {}).get("role", "assistant"),
-                        "content": choice.get("message", {}).get("content") or "",
+                        "role": message_data.get("role") or "assistant",
+                        "content": message_data.get("content") or "",
                     }
                     sanitized_choice: CompletionChoice = {
                         "index": choice.get("index", 0),


### PR DESCRIPTION
## Summary
- Fixes bug in `GitHubModelsProvider` where API responses with `null` or malformed `message` fields cause errors
- Adds robust handling for cases where `message` is `null`, missing, or not a dictionary
- Ensures default values (`role: assistant`, `content: ""`) are used when message data is invalid or incomplete
- Adds comprehensive async tests covering various malformed message scenarios

## Changes

### Core Fixes
- Updated `GitHubModelsProvider` to safely extract `message` from choices, defaulting to empty dict if `message` is `null` or not a dict
- Defaulted `role` to "assistant" and `content` to empty string when missing or null

### Tests
- Added async tests in `test_github_models.py` to cover:
  - API responses with `message: null`
  - `message` as wrong types (string, number, list)
  - Missing `message` field
  - Partial message fields with `null` values
- Tests verify that the provider gracefully handles these cases without errors and returns expected defaults

## Test plan
- Run all new and existing tests to ensure no regressions
- Confirm that the provider returns valid completion responses even with malformed API data
- Verify coverage of edge cases for message parsing in GitHubModelsProvider

This fix improves the robustness of the GitHubModelsProvider against unexpected API response formats, preventing runtime errors and ensuring consistent behavior.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4e464109-d09b-4d75-9df9-38027c4ed821